### PR TITLE
Fix issue with `returnFocusOnDeactivate` not working when `active` pr…

### DIFF
--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -48,7 +48,18 @@ class FocusTrap extends React.Component {
       const returnFocus = returnFocusOnDeactivate || false;
       const config = { returnFocus };
       this.focusTrap.deactivate(config);
+      if (
+        returnFocusOnDeactivate !== false &&
+        this.previouslyFocusedElement &&
+        this.previouslyFocusedElement.focus
+      ) {
+        this.previouslyFocusedElement.focus();
+      }
     } else if (!prevProps.active && this.props.active) {
+      if (typeof document !== 'undefined') {
+        this.previouslyFocusedElement = document.activeElement;
+      }
+
       this.focusTrap.activate();
     }
 


### PR DESCRIPTION
focus-trap-react can be activated/deactivated by either mounting/unmounting the component, or by passing a boolean value to the `active` prop. When using the latter method, there is an issue where the focus is not returned on deactivation.

Explicitly setting `returnFocusOnDeactivate` to true partially fixes the problem, but the issue persists when deactivation is triggered via the ESCAPE key.

I think the cause of the issue is that the component references `this.previouslyFocusedElement` when mounting/unmounting but not when a prop is updated.