### PR TITLE
[Bugfix] ServerSideRender Proptype failing because of Element not being defined

### DIFF
--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -113,6 +113,8 @@ class FocusTrap extends React.Component {
   }
 }
 
+const _Element = typeof Element === 'undefined' ? function () {} : Element;
+
 FocusTrap.propTypes = {
   active: PropTypes.bool,
   paused: PropTypes.bool,
@@ -120,12 +122,12 @@ FocusTrap.propTypes = {
     onActivate: PropTypes.func,
     onDeactivate: PropTypes.func,
     initialFocus: PropTypes.oneOfType([
-      PropTypes.instanceOf(Element),
+      PropTypes.instanceOf(_Element),
       PropTypes.string,
       PropTypes.func
     ]),
     fallbackFocus: PropTypes.oneOfType([
-      PropTypes.instanceOf(Element),
+      PropTypes.instanceOf(_Element),
       PropTypes.string,
       PropTypes.func
     ]),
@@ -133,7 +135,7 @@ FocusTrap.propTypes = {
     clickOutsideDeactivates: PropTypes.bool,
     returnFocusOnDeactivate: PropTypes.bool,
     setReturnFocus: PropTypes.oneOfType([
-      PropTypes.instanceOf(Element),
+      PropTypes.instanceOf(_Element),
       PropTypes.string,
       PropTypes.func
     ]),
@@ -142,7 +144,7 @@ FocusTrap.propTypes = {
   }),
   children: PropTypes.oneOfType([
     PropTypes.element, // React element
-    PropTypes.instanceOf(Element) // DOM element
+    PropTypes.instanceOf(_Element) // DOM element
   ])
 
   // NOTE: _createFocusTrap is internal, for testing purposes only, so we don't


### PR DESCRIPTION
Checking global `Element` to avoid SSR error `[ error ] ReferenceError: Element is not defined`