### PR TITLE
feat: Add boolean value support for allowOutsideClick option

### DIFF
--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -42,18 +42,6 @@ class FocusTrap extends React.Component {
         continue;
       }
 
-      /**
-       * If a boolean value is passed to 'allowOutsideClick',
-       * wrap it in a function that returns that value
-       */
-      if (
-        optionName === 'allowOutsideClick' &&
-        typeof specifiedFocusTrapOptions[optionName] === 'boolean'
-      ) {
-        tailoredFocusTrapOptions[optionName] = () =>
-          specifiedFocusTrapOptions[optionName];
-      }
-
       tailoredFocusTrapOptions[optionName] =
         specifiedFocusTrapOptions[optionName];
     }

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -42,6 +42,18 @@ class FocusTrap extends React.Component {
         continue;
       }
 
+      /**
+       * If a boolean value is passed to 'allowOutsideClick',
+       * wrap it in a function that returns that value
+       */
+      if (
+        optionName === 'allowOutsideClick' &&
+        typeof specifiedFocusTrapOptions[optionName] === 'boolean'
+      ) {
+        tailoredFocusTrapOptions[optionName] = () =>
+          specifiedFocusTrapOptions[optionName];
+      }
+
       tailoredFocusTrapOptions[optionName] =
         specifiedFocusTrapOptions[optionName];
     }
@@ -140,7 +152,7 @@ FocusTrap.propTypes = {
       PropTypes.string,
       PropTypes.func
     ]),
-    allowOutsideClick: PropTypes.func,
+    allowOutsideClick: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
     preventScroll: PropTypes.bool
   }),
   children: PropTypes.oneOfType([


### PR DESCRIPTION
## Description

This PR adds support for a boolean to be passed to `allowOutsideClick` in the `focusTrapOptions` object. The changes were all suggested in #86 

**Update**: This PR is now a follow-up to https://github.com/focus-trap/focus-trap/pull/120

## Considerations

### Tests

There are no unit tests for the `tailoredFocusTrapOptions`, so there are currently no tests in this PR. I would prefer that that not be the case.

I suggest we pull the transformation of `specifiedFocusTrapOptions` into `tailoredFocusTrapOptions` into a separate function that we can test in isolation. That way we can have confidence that we are tailoring the options correctly for use by [`focus-trap`](https://github.com/davidtheclark/focus-trap).

### Documentation

~~The [`README.md`](README.md) only makes [a blanket statement about `focusTrapOptions`](https://github.com/focus-trap/focus-trap-react#focustrapoptions). As a result, there is not a clear way to document this feature.~~

~~At the risk of introducing some redundancy between this library and `focus-trap`, I suggest that we add _some_ option documentation to help users who stumble on this library first.~~

These concerns have been addressed in https://github.com/focus-trap/focus-trap/pull/120

## Next steps

- [ ] Code review
- [ ] Decisions on:
  - [ ] Adding tests
  - ~~Adding documentation~~

Let me know if there is anything else I can do in the meantime.