### PR TITLE
Remove call for maintainers

### DIFF
--- a/.changeset/moody-apples-report.md
+++ b/.changeset/moody-apples-report.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': patch
+---
+
+Remove call for maintainers. @stefcameron and @maraisr hope to take up the charge. Additional help and contributors are most welcome for anyone interested!

--- a/README.md
+++ b/README.md
@@ -1,12 +1,5 @@
 # focus-trap-react [![CI](https://github.com/focus-trap/focus-trap-react/workflows/CI/badge.svg?branch=master&event=push)](https://github.com/focus-trap/focus-trap-react/actions?query=workflow:CI+branch:master)
 
----
-
-**SEEKING CO-MAINTAINERS!** Continued development of this project is going to require the work of one or more dedicated co-maintainers (or forkers). If you're interested, please comment in [this issue](https://github.com/focus-trap/focus-trap-react/issues/48).
-
----
-
-
 A React component that traps focus.
 
 This component is a light wrapper around [focus-trap](https://github.com/focus-trap/focus-trap),


### PR DESCRIPTION
Fixes #48 now that we're 2 maintainers taking over. Based on the
amount of activity and the stability of the code base, I think we
should be good for a bit.