### PR TITLE
Add e2e testing to NPM test script and readme update

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,12 +161,16 @@ If you would like to pause or unpause the focus trap (see [`focus-trap`'s docume
 
 Please note that this project is released with a Contributor Code of Conduct. By participating in this project you agree to abide by its terms.
 
-Format with `npm run format`.
+Format with `yarn format`.
 
-Lint with `npm run lint`.
+Lint with `yarn lint`.
 
-Run the demos with `npm start`.
+Run the demos with `yarn start`.
 
-Test with `npm run test` (checks formatting, checks lint, runs tests).
+Test with `yarn test` (checks formatting, checks lint, runs both unit and E2E tests).  
+To troubleshoot headless E2E test failures, recording can be found at `cypress/videos/*.mp4`.  
+Note: By default `chrome` is the browser on which headless E2E test are running
 
-Unit test (only) with `npm run test-unit`.
+Unit test (only) with `yarn test-unit`.
+
+E2E test can alo be run in headed mode on Cypress interactive UI which is easier for development and troubleshoot with `yarn test-cypress`.   

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test-unit": "jest",
     "test-cypress": "start-server-and-test start 9966 'cypress open'",
     "test-cypress-ci": "start-server-and-test start 9966 'cypress run --browser $CYPRESS_BROWSER --headless'",
-    "test": "yarn format-check && yarn lint && yarn test-unit && yarn test-types",
+    "test": "yarn format-check && yarn lint && yarn test-unit && yarn test-types && CYPRESS_BROWSER=chrome yarn test-cypress-ci",
     "prepublishOnly": "yarn build",
     "release": "yarn build && changeset publish"
   },


### PR DESCRIPTION
- Update readme with `yarn`
- Update readme with E2E testing guidance
- Include E2E testing as part of `test` npm script