### PR TITLE
prepublishOnly -> prepare

### DIFF
--- a/.changeset/good-cups-collect.md
+++ b/.changeset/good-cups-collect.md
@@ -1,0 +1,5 @@
+---
+"focus-trap-react": patch
+---
+
+Change `prepublishOnly` script to `prepare` script so that it also runs if someone installs the package directly from the git repo (e.g. from your work in which you fixed a bug or added a feature you're waiting to get merged to master and published to NPM).

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test-cypress": "start-server-and-test start 9966 'cypress open'",
     "test-cypress-ci": "start-server-and-test start 9966 'cypress run --browser $CYPRESS_BROWSER --headless'",
     "test": "yarn format-check && yarn lint && yarn test-unit && yarn test-types && CYPRESS_BROWSER=chrome yarn test-cypress-ci",
-    "prepublishOnly": "yarn build",
+    "prepare": "yarn build",
     "release": "yarn build && changeset publish"
   },
   "repository": {


### PR DESCRIPTION
This will cause the script (i.e. the build) to run:

1. when you run `yarn install` in the project after cloning the repo;
2. before publishing;
3. when installing the package from its git repo (an undocumented feature),
    which is convenient if someone forks the repo to fix a bug and installs the
    package from their fork until the bug fix is merged and a new package
    version published.

Thanks to https://github.com/focus-trap/tabbable/pull/60 for pointing this out!