### PR TITLE
Fix focus not always returning to expected element on active=false

### DIFF
--- a/.changeset/strong-emus-do.md
+++ b/.changeset/strong-emus-do.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': patch
+---
+
+Fix focus not always returning to correct node after setting `active` prop to `false`.

--- a/.changeset/strong-emus-do.md
+++ b/.changeset/strong-emus-do.md
@@ -2,4 +2,4 @@
 'focus-trap-react': patch
 ---
 
-Fix focus not always returning to correct node after setting `active` prop to `false`.
+Fix focus not always returning to correct node after setting `active` prop to `false`. #139

--- a/cypress/integration/focus-trap-demo.spec.js
+++ b/cypress/integration/focus-trap-demo.spec.js
@@ -13,145 +13,232 @@ describe('<FocusTrap> component', () => {
     cy.get(focusedElAlias).should('be.focused');
   }
 
-  it('By default focus first element in its tab order and trap focus within its children', () => {
-    cy.get('#demo-defaults').as('testRoot');
+  describe('demo: defaults', () => {
+    it('By default focus first element in its tab order and trap focus within its children', () => {
+      cy.get('#demo-defaults').as('testRoot');
 
-    // activate trap
-    cy.get('@testRoot')
-      .findByRole('button', { name: 'activate trap' })
-      .as('lastlyFocusedElementBeforeTrapIsActivated')
-      .click();
+      // activate trap
+      cy.get('@testRoot')
+        .findByRole('button', { name: 'activate trap' })
+        .as('lastlyFocusedElementBeforeTrapIsActivated')
+        .click();
 
-    // 1st element should be focused
-    cy.get('@testRoot')
-      .findByRole('link', { name: 'with' })
-      .as('firstElementInTrap')
-      .should('be.focused');
+      // 1st element should be focused
+      cy.get('@testRoot')
+        .findByRole('link', { name: 'with' })
+        .as('firstElementInTrap')
+        .should('be.focused');
 
-    // crucial focus-trap feature: mouse click is trapped
-    verifyCrucialFocusTrapOnClicking('@firstElementInTrap');
+      // crucial focus-trap feature: mouse click is trapped
+      verifyCrucialFocusTrapOnClicking('@firstElementInTrap');
 
-    // trap is active(keep focus in trap by tabbing through the focus trap's tabbable elements)
-    cy.get('@firstElementInTrap')
-      .tab()
-      .should('have.text', 'some')
-      .should('be.focused')
-      .tab()
-      .should('have.text', 'focusable')
-      .should('be.focused')
-      .tab()
-      .as('lastElementInTrap')
-      .should('have.text', 'deactivate trap')
-      .should('be.focused')
-      .tab();
+      // trap is active(keep focus in trap by tabbing through the focus trap's tabbable elements)
+      cy.get('@firstElementInTrap')
+        .tab()
+        .should('have.text', 'some')
+        .should('be.focused')
+        .tab()
+        .should('have.text', 'focusable')
+        .should('be.focused')
+        .tab()
+        .as('lastElementInTrap')
+        .should('have.text', 'deactivate trap')
+        .should('be.focused')
+        .tab();
 
-    // trap is active(keep focus in trap by shift-tabbing through the focus trap's tabbable elements)
-    cy.get('@firstElementInTrap').should('be.focused').tab({ shift: true });
-    cy.get('@lastElementInTrap').should('be.focused');
+      // trap is active(keep focus in trap by shift-tabbing through the focus trap's tabbable elements)
+      cy.get('@firstElementInTrap').should('be.focused').tab({ shift: true });
+      cy.get('@lastElementInTrap').should('be.focused');
 
-    // trap can be deactivated and return focus to lastly focused element before trap is activated
-    cy.get('@testRoot')
-      .findByRole('button', { name: 'deactivate trap' })
-      .click();
-    cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should('have.focus');
+      // trap can be deactivated and return focus to lastly focused element before trap is activated
+      cy.get('@testRoot')
+        .findByRole('button', { name: 'deactivate trap' })
+        .click();
+      cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should('have.focus');
 
-    // focus can be transitioned freely when trap is unmounted
-    let previousFocusedEl;
-    cy.get('@lastlyFocusedElementBeforeTrapIsActivated')
-      .then(([lastlyFocusedEl]) => (previousFocusedEl = lastlyFocusedEl))
-      .tab();
-    cy.focused().should(([nextFocusedEl]) =>
-      expect(nextFocusedEl).not.equal(previousFocusedEl)
-    );
+      // focus can be transitioned freely when trap is unmounted
+      let previousFocusedEl;
+      cy.get('@lastlyFocusedElementBeforeTrapIsActivated')
+        .then(([lastlyFocusedEl]) => (previousFocusedEl = lastlyFocusedEl))
+        .tab();
+      cy.focused().should(([nextFocusedEl]) =>
+        expect(nextFocusedEl).not.equal(previousFocusedEl)
+      );
+    });
   });
 
-  it('On trap mounts and activates, focus on manually specified input element', () => {
-    cy.get('#demo-ffne').as('testRoot');
+  describe('demo: ffne', () => {
+    it('On trap mounts and activates, focus on manually specified input element', () => {
+      cy.get('#demo-ffne').as('testRoot');
 
-    // activate trap
-    cy.get('@testRoot').findByRole('button', { name: 'activate trap' }).click();
+      // activate trap
+      cy.get('@testRoot')
+        .findByRole('button', { name: 'activate trap' })
+        .click();
 
-    // instead of next tab-order element being focused, element specified should be focused
-    cy.get('@testRoot')
-      .findByRole('textbox', { name: 'Initially focused input' })
-      .as('focusedEl')
-      .should('be.focused');
+      // instead of next tab-order element being focused, element specified should be focused
+      cy.get('@testRoot')
+        .findByRole('textbox', { name: 'Initially focused input' })
+        .as('focusedEl')
+        .should('be.focused');
 
-    // crucial focus-trap feature: mouse click is trapped
-    verifyCrucialFocusTrapOnClicking('@focusedEl');
+      // crucial focus-trap feature: mouse click is trapped
+      verifyCrucialFocusTrapOnClicking('@focusedEl');
+    });
+
+    it('Escape key does not deactivate trap. Instead, click on "deactivate trap" to deactivate trap', () => {
+      cy.get('#demo-ffne').as('testRoot');
+
+      // activate trap
+      cy.get('@testRoot')
+        .findByRole('button', { name: 'activate trap' })
+        .as('lastlyFocusedElementBeforeTrapIsActivated')
+        .click();
+
+      // trying deactivate trap by ESC
+      cy.get('@testRoot')
+        .findByRole('textbox', { name: 'Initially focused input' })
+        .as('trapChild')
+        .focus()
+        .type('{esc}');
+
+      // ESC does not deactivate the trap
+      cy.get('@trapChild').should('exist').should('be.focused');
+
+      // crucial focus-trap feature: mouse click is trapped
+      verifyCrucialFocusTrapOnClicking('@trapChild');
+
+      // click on deactivate trap button to deactivate trap
+      cy.get('@testRoot')
+        .findByRole('button', { name: 'deactivate trap' })
+        .click();
+      cy.get('@trapChild').should('not.exist');
+      cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should('be.focused');
+    });
   });
 
-  it('Escape key does not deactivate trap. Instead, click on "deactivate trap" to deactivate trap', () => {
-    cy.get('#demo-ffne').as('testRoot');
+  describe('demo: special element', () => {
+    // because this test allows click-through to deactivate, we can't use
+    //  verifyCrucialFocusTrapOnClicking() because it clicks outside, and will
+    //  cause the trap to be deactivated
+    const verifyFocusTrapped = function () {
+      // 1st element should be focused
+      cy.get('@testRoot')
+        .findByRole('link', { name: 'with' })
+        .as('firstElementInTrap')
+        .should('be.focused');
 
-    // activate trap
-    cy.get('@testRoot')
-      .findByRole('button', { name: 'activate trap' })
-      .as('lastlyFocusedElementBeforeTrapIsActivated')
-      .click();
+      // trap is active(keep focus in trap by tabbing through the focus trap's tabbable elements)
+      cy.get('@firstElementInTrap')
+        .tab()
+        .should('have.text', 'some')
+        .should('be.focused')
+        .tab()
+        .should('have.text', 'focusable')
+        .should('be.focused')
+        .tab()
+        .as('lastElementInTrap')
+        .should('have.text', 'deactivate trap')
+        .should('be.focused')
+        .tab();
 
-    // trying deactivate trap by ESC
-    cy.get('@testRoot')
-      .findByRole('textbox', { name: 'Initially focused input' })
-      .as('trapChild')
-      .focus()
-      .type('{esc}');
+      // trap is active(keep focus in trap by shift-tabbing through the focus trap's tabbable elements)
+      cy.get('@firstElementInTrap').should('be.focused').tab({ shift: true });
+      cy.get('@lastElementInTrap').should('be.focused');
+    };
 
-    // ESC does not deactivate the trap
-    cy.get('@trapChild').should('exist').should('be.focused');
+    it('Can be deactivated while staying mounted by clicking on deactivate', () => {
+      cy.get('#demo-special-element').as('testRoot');
 
-    // crucial focus-trap feature: mouse click is trapped
-    verifyCrucialFocusTrapOnClicking('@trapChild');
+      // activate trap
+      cy.get('@testRoot')
+        .findByRole('button', { name: 'activate trap' })
+        .as('lastlyFocusedElementBeforeTrapIsActivated')
+        .click();
 
-    // click on deactivate trap button to deactivate trap
-    cy.get('@testRoot')
-      .findByRole('button', { name: 'deactivate trap' })
-      .click();
-    cy.get('@trapChild').should('not.exist');
-    cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should('be.focused');
+      verifyFocusTrapped();
+
+      cy.get('@testRoot')
+        .findByRole('button', { name: 'deactivate trap' })
+        .as('trapChild')
+        .click();
+
+      cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should('be.focused');
+
+      // stay mounted after deactivation
+      cy.get('@trapChild').should('exist');
+    });
+
+    it('Can be deactivated while staying mounted by pressing ESC key', () => {
+      cy.get('#demo-special-element').as('testRoot');
+
+      // activate trap
+      cy.get('@testRoot')
+        .findByRole('button', { name: 'activate trap' })
+        .as('lastlyFocusedElementBeforeTrapIsActivated')
+        .click();
+
+      verifyFocusTrapped();
+
+      cy.get('@testRoot')
+        .findByRole('button', { name: 'deactivate trap' })
+        .as('trapChild')
+        .type('{esc}');
+
+      cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should('be.focused');
+
+      // stay mounted after deactivation
+      cy.get('@trapChild').should('exist');
+    });
+
+    it('Can click outside of trap to deactivate and click carries through', () => {
+      cy.get('#demo-special-element').as('testRoot');
+
+      // activate trap
+      cy.get('@testRoot')
+        .findByRole('button', { name: 'activate trap' })
+        .as('lastlyFocusedElementBeforeTrapIsActivated')
+        .click();
+
+      verifyFocusTrapped();
+
+      cy.get('@testRoot')
+        .findByRole('button', { name: 'deactivate trap' })
+        .as('trapChild');
+
+      // click outside to deactivate trap and also click carries through
+      cy.findByRole('button', { name: 'pass thru click' })
+        .as('passThru')
+        .click();
+
+      // activate button should NOT be focused because click should've gone through to passThru button
+      cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should(
+        'not.be.focused'
+      );
+
+      // stay mounted after deactivation
+      cy.get('@trapChild').should('exist');
+
+      // passThru button has focus and click event was processed
+      cy.get('@passThru').should('be.focused');
+      cy.get('@testRoot').findByText('Clicked!');
+    });
   });
 
-  it('Can be deactivated while staying mounted  ', () => {
-    cy.get('#demo-special-element').as('testRoot');
+  describe('demo: autofocus', () => {
+    it('Focus on element with "autofocus" attribute than the 1st tab order element within mounted trap children', () => {
+      cy.get('#demo-autofocus').as('testRoot');
 
-    // activate trap
-    cy.get('@testRoot')
-      .findByRole('button', { name: 'activate trap' })
-      .as('lastlyFocusedElementBeforeTrapIsActivated')
-      .click();
+      // activate trap
+      cy.get('@testRoot')
+        .findByRole('button', { name: 'activate trap' })
+        .click();
 
-    // stay mounted after deactivation
-    cy.get('@testRoot')
-      .findByRole('button', { name: 'deactivate trap' })
-      .as('trapChild')
-      .click();
-    cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should('be.focused');
-    cy.get('@trapChild').should('exist');
-  });
+      // element with "autofocus" attribute is focused
+      cy.findByTestId('autofocus-el').as('trapChild').should('be.focused');
 
-  it('Can click outside of trap to deactivate and click carries through  ', () => {
-    cy.get('#demo-special-element').as('testRoot');
-
-    // activate trap
-    cy.get('@testRoot').findByRole('button', { name: 'activate trap' }).click();
-
-    // click outside to deactivate trap and also click carries through
-    cy.findByRole('button', { name: 'pass thru click' })
-      .click()
-      .should('be.focused');
-    cy.get('@testRoot').findByText('Clicked!');
-  });
-
-  it('Focus on element with "autofocus" attribute than the 1st tab order element within mounted trap children', () => {
-    cy.get('#demo-autofocus').as('testRoot');
-
-    // activate trap
-    cy.get('@testRoot').findByRole('button', { name: 'activate trap' }).click();
-
-    // element with "autofocus" attribute is focused
-    cy.findByTestId('autofocus-el').as('trapChild').should('be.focused');
-
-    // crucial focus-trap feature: mouse click is trapped
-    verifyCrucialFocusTrapOnClicking('@trapChild');
+      // crucial focus-trap feature: mouse click is trapped
+      verifyCrucialFocusTrapOnClicking('@trapChild');
+    });
   });
 });

--- a/test/deactivation.test.js
+++ b/test/deactivation.test.js
@@ -67,7 +67,7 @@ describe('deactivation', () => {
     expect(mockFocusTrap.deactivate).toHaveBeenCalledTimes(1);
   });
 
-  test('deactivation respects `returnFocusOnDeactivate` option', () => {
+  describe('deactivation respects `returnFocusOnDeactivate` option', () => {
     class TestZone extends React.Component {
       state = {
         trapActive: true,
@@ -87,7 +87,8 @@ describe('deactivation', () => {
               ref={(component) => (this.trap = component)}
               _createFocusTrap={mockCreateFocusTrap}
               active={this.state.trapActive}
-              focusTrapOptions={{ returnFocusOnDeactivate: true }}
+              // eslint-disable-next-line react/prop-types
+              focusTrapOptions={this.props.trapOptions}
             >
               <div>
                 <button>something special</button>
@@ -98,15 +99,79 @@ describe('deactivation', () => {
       }
     }
 
-    const zone = ReactDOM.render(<TestZone />, domContainer);
-    // mock deactivate on the fouscTrap instance for we can asset
-    // that we are passing the correct config to the focus trap.
-    zone.trap.focusTrap.deactivate = jest.fn();
+    test('returnFocusOnDeactivate = true', () => {
+      const zone = ReactDOM.render(
+        <TestZone trapOptions={{ returnFocusOnDeactivate: true }} />,
+        domContainer
+      );
 
-    TestUtils.Simulate.click(ReactDOM.findDOMNode(zone.refs.trigger));
+      // mock deactivate on the focusTrap instance so we can assert
+      // that we are passing the correct config to the focus trap.
+      zone.trap.focusTrap.deactivate = jest.fn();
 
-    expect(zone.trap.focusTrap.deactivate).toHaveBeenCalledWith({
-      returnFocus: true,
+      // mock the FocusTrap instance's returnFocus() method so we can make sure
+      //  it gets called
+      zone.trap.returnFocus = jest.fn();
+
+      TestUtils.Simulate.click(ReactDOM.findDOMNode(zone.refs.trigger));
+
+      // we should always be calling deactivate() with returnFocus=false since
+      //  we take care of returning focus ourselves
+      expect(zone.trap.focusTrap.deactivate).toHaveBeenCalledWith({
+        returnFocus: false,
+      });
+
+      // since we set returnFocusOnDeactivate=true, FocusTrap should've tried to return focus
+      expect(zone.trap.returnFocus).toHaveBeenCalled();
+    });
+
+    test('returnFocusOnDeactivate = false', () => {
+      const zone = ReactDOM.render(
+        <TestZone trapOptions={{ returnFocusOnDeactivate: false }} />,
+        domContainer
+      );
+
+      // mock deactivate on the focusTrap instance so we can assert
+      // that we are passing the correct config to the focus trap.
+      zone.trap.focusTrap.deactivate = jest.fn();
+
+      // mock the FocusTrap instance's returnFocus() method so we can make sure
+      //  it gets called
+      zone.trap.returnFocus = jest.fn();
+
+      TestUtils.Simulate.click(ReactDOM.findDOMNode(zone.refs.trigger));
+
+      // we should always be calling deactivate() with returnFocus=false since
+      //  we take care of returning focus ourselves
+      expect(zone.trap.focusTrap.deactivate).toHaveBeenCalledWith({
+        returnFocus: false,
+      });
+
+      // since we set returnFocusOnDeactivate=false, FocusTrap should NOT have tried to return focus
+      expect(zone.trap.returnFocus).not.toHaveBeenCalled();
+    });
+
+    test('returnFocusOnDeactivate defaults to true', () => {
+      const zone = ReactDOM.render(<TestZone />, domContainer);
+
+      // mock deactivate on the focusTrap instance so we can assert
+      // that we are passing the correct config to the focus trap.
+      zone.trap.focusTrap.deactivate = jest.fn();
+
+      // mock the FocusTrap instance's returnFocus() method so we can make sure
+      //  it gets called
+      zone.trap.returnFocus = jest.fn();
+
+      TestUtils.Simulate.click(ReactDOM.findDOMNode(zone.refs.trigger));
+
+      // we should always be calling deactivate() with returnFocus=false since
+      //  we take care of returning focus ourselves
+      expect(zone.trap.focusTrap.deactivate).toHaveBeenCalledWith({
+        returnFocus: false,
+      });
+
+      // since default is returnFocusOnDeactivate=true, FocusTrap should've tried to return focus
+      expect(zone.trap.returnFocus).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
This is a new fix for the issue identified in #54 after gaining
a better understanding of the issue.

The `returnFocusOnDeactivate` flag was being special-cased, but
not always, and the element to which focus should be returned,
which focus-trap-react attempts to manage on its own (see
class Constructor comment for reasoning), was not always correct.
For example, if the trap was deactivated, and then re-activated,
the 'last focused element before activation' wasn't updated at
the moment of re-activation, where it could've changed.

###  Features and Bug Fixes

- [x] Issue being fixed is referenced.
- [x] Unit test coverage added/updated.
- [x] E2E test coverage added/updated.
- [x] ~Prop-types added/updated.~
- [x] ~Typings added/updated.~
- [x] ~README updated (API changes, instructions, etc.).~
- [x] ~Changes to dependencies explained.~
- [x] Changeset added (run `yarn changeset` locally to add one, follow prompts).
