### PR TITLE
Fixes reference to non-existent demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Type: `Boolean`, optional
 
 By default, the `FocusTrap` activates when it mounts. So you activate and deactivate it via mounting and unmounting. If, however, you want to keep the `FocusTrap` mounted *while still toggling its activation state*, you can do that with this prop.
 
-See `demo/demo-three.jsx`.
+See `demo/demo-special-element.js`.
 
 #### paused
 


### PR DESCRIPTION
Demo for `active` prop no longer existed or was renamed to `demo-special-element.js`

Thank you for your contribution! 🎉

Here are a few checks to help us make this the _best PR ever_ depending on the nature of your changes.

🥦 Please __replace these lines above with your PR message__, and remove the section below that doesn't apply:

###  Features and Bug Fixes

- [ ] ~~Issue being fixed is referenced.~~
- [ ] ~~Unit test coverage added/updated.~~
- [ ] ~~E2E test coverage added/updated.~~
- [ ] ~~Prop-types added/updated.~~
- [ ] ~~Typings added/updated.~~
- [X] README updated (API changes, instructions, etc.).
- [ ] ~~Changes to dependencies explained.~~
- [ ] ~~Changeset added (run `yarn changeset` locally to add one, follow prompts).~~

👉 If any of these don't apply, please ~cross them out~.

### Tooling

- [ ] ~~Issue being fixed is referenced.~~
- [ ] ~~Changes to dependencies explained.~~
- [X] README instructions updated.
- [X] A Changeset is __not__ added.

👉 If any of these don't apply, please ~cross them out~.
