### PR TITLE
Update focus-trap dependency to 6.1.4

### DIFF
--- a/.changeset/yellow-carpets-talk.md
+++ b/.changeset/yellow-carpets-talk.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': patch
+---
+
+Update focus-trap dependency to [6.1.4](https://github.com/focus-trap/focus-trap/blob/master/CHANGELOG.md#614)

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "typescript": "^4.0.3"
   },
   "dependencies": {
-    "focus-trap": "^6.1.3"
+    "focus-trap": "^6.1.4"
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4066,12 +4066,12 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-focus-trap@^6.1.3:
-  version "6.1.3"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.1.3.tgz#38b79099bec42b9efa9ee47b646a21033dd030fd"
-  integrity sha512-UXrRlMIZVwLRt4t/fdhExuD3nanc2oHlyJrjbUl01iR2Z59/uPOAj4V9A6k2aelLb/aKb3YKJG+S4HBTrnTWHA==
+focus-trap@^6.1.4:
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.1.4.tgz#6297a9f0f45a84377b60e9a8c0d1f8a5b98d94d2"
+  integrity sha512-jgNc+O8UkGsUpdhNXkyonwlw4i707+ESAWv1vCbyd8+29db5/Wv1BkJImDczfEWMu9O635FvM5ABOjeyqNQpEQ==
   dependencies:
-    tabbable "^5.1.2"
+    tabbable "^5.1.3"
 
 follow-redirects@1.5.10:
   version "1.5.10"
@@ -7986,10 +7986,10 @@ syntax-error@^1.1.1:
   dependencies:
     acorn-node "^1.2.0"
 
-tabbable@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.2.tgz#3c4eac2901d0000913d13ce147229eb1405b59ca"
-  integrity sha512-DNmnX4XgkjK7kxDnQ5IbyYoNke2izMk5b62All0qxzoCF3wE7H9CuZ2IPdfAN8v79E0rpjv2k78uWuIXupGa9g==
+tabbable@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.1.3.tgz#8bb22b620d5a54d575c3243e4a324bd36acf99ec"
+  integrity sha512-jqR3rOgeyNlYWDWoyjNTWuHk3+FObu3Fw4e0zjeOLBicI74TT/wGrvSbJUaFVs7FMfiY0Ee8CKM7QaJwVMT4YA==
 
 table@^5.2.3:
   version "5.4.6"


### PR DESCRIPTION
This picks-up bug fixes in downstream tabbable 5.1.3

- [x] ~Issue being fixed is referenced.~
- [x] Changes to dependencies explained.
- [x] ~README instructions updated.~
- [x] A Changeset is added.
