### PR TITLE
Add ability to pass containerElements to focus-trap

### DIFF
--- a/.changeset/young-crews-report.md
+++ b/.changeset/young-crews-report.md
@@ -1,5 +1,5 @@
 ---
-'focus-trap-react': patch
+'focus-trap-react': minor
 ---
 
-Add ability to pass containerElements to focus-trap
+Add ability to pass containerElements to focus-trap #179.  This PR is made possible because of https://github.com/focus-trap/focus-trap/pull/217.

--- a/.changeset/young-crews-report.md
+++ b/.changeset/young-crews-report.md
@@ -2,4 +2,4 @@
 'focus-trap-react': minor
 ---
 
-Add ability to pass containerElements to focus-trap #179.  This PR is made possible because of https://github.com/focus-trap/focus-trap/pull/217.
+Add ability to pass containerElements to focus-trap #179.  This PR is made possible because of https://github.com/focus-trap/focus-trap/pull/217 and the released version 6.2.0 of focus-trap.

--- a/.changeset/young-crews-report.md
+++ b/.changeset/young-crews-report.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': patch
+---
+
+Add ability to pass containerElements to focus-trap

--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ Type: `Boolean`, optional
 
 If you would like to pause or unpause the focus trap (see [`focus-trap`'s documentation](https://github.com/focus-trap/focus-trap#focustrappause)), toggle this prop.
 
+#### containerElements
+
+Type: `Array of Elements`, optional
+
+If passed in, these elements will be used as the boundaries for the focus-trap, instead of the child.  These get passed as arguments to focus-trap's updateContainerElements method.
+
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ If you would like to pause or unpause the focus trap (see [`focus-trap`'s docume
 
 #### containerElements
 
-Type: `Array of Elements`, optional
+Type: `Array of HTMLElement`, optional
 
 If passed in, these elements will be used as the boundaries for the focus-trap, instead of the child.  These get passed as arguments to focus-trap's updateContainerElements method.
 

--- a/cypress/integration/focus-trap-demo.spec.js
+++ b/cypress/integration/focus-trap-demo.spec.js
@@ -242,7 +242,7 @@ describe('<FocusTrap> component', () => {
     });
   });
 
-  describe.only('demo: containerElements prop', () => {
+  describe('demo: containerElements prop', () => {
     it('containerElements can be passed in and used as multiple boundaries to keep the focus within', () => {
       cy.get('#demo-containerelements').as('testRoot');
 

--- a/cypress/integration/focus-trap-demo.spec.js
+++ b/cypress/integration/focus-trap-demo.spec.js
@@ -241,4 +241,64 @@ describe('<FocusTrap> component', () => {
       verifyCrucialFocusTrapOnClicking('@trapChild');
     });
   });
+
+  describe.only('demo: containerElements prop', () => {
+    it('containerElements can be passed in and used as multiple boundaries to keep the focus within', () => {
+      cy.get('#demo-containerelements').as('testRoot');
+
+      // activate trap
+      cy.get('@testRoot')
+        .findByRole('button', { name: 'activate trap' })
+        .as('lastlyFocusedElementBeforeTrapIsActivated')
+        .click();
+
+      // 1st element should be focused
+      cy.get('@testRoot')
+        .findByRole('link', { name: 'with' })
+        .as('firstElementInTrap')
+        .should('be.focused');
+
+      // trap is active(keep focus in trap by tabbing through the focus trap's tabbable elements)
+      cy.get('@firstElementInTrap')
+        .tab()
+        .should('have.text', 'some')
+        .should('be.focused')
+        .tab()
+        .should('have.text', 'focusable')
+        .should('be.focused')
+        .tab()
+        .should('have.text', 'See')
+        .should('be.focused')
+        .tab()
+        .should('have.text', 'how')
+        .should('be.focused')
+        .tab()
+        .should('have.text', 'works')
+        .should('be.focused')
+        .tab()
+        .should('have.text', 'with')
+        .should('be.focused')
+        .tab({ shift: true })
+        .should('have.text', 'works')
+        .should('be.focused')
+        .tab({ shift: true })
+        .should('have.text', 'how')
+        .should('be.focused')
+        .tab({ shift: true })
+        .should('have.text', 'See')
+        .should('be.focused')
+        .tab({ shift: true })
+        .should('have.text', 'focusable')
+        .should('be.focused')
+        .tab({ shift: true })
+        .should('have.text', 'some')
+        .should('be.focused')
+        .tab({ shift: true })
+        .should('have.text', 'with')
+        .should('be.focused')
+        .tab({ shift: true })
+        .should('have.text', 'works')
+        .should('be.focused');
+    });
+  });
 });

--- a/demo/index.html
+++ b/demo/index.html
@@ -57,6 +57,12 @@
   </p>
   <div id="demo-autofocus"></div>
 
+  <h2>demo containerElements</h2>
+  <p>
+    You may pass in an array prop `containerElements` that contains nodes to trap focus within, which if passed will be used instead of the direct child.
+  </p>
+  <div id="demo-containerelements"></div>
+
   <p>
     <span style="font-size:2em;vertical-align:middle;">☜</span>
     <a href="https://github.com/focus-trap/focus-trap-react" style="vertical-align:middle;">Return to the repository</a>

--- a/demo/js/demo-containerelements.js
+++ b/demo/js/demo-containerelements.js
@@ -1,0 +1,82 @@
+const React = require('react');
+const ReactDOM = require('react-dom');
+const FocusTrap = require('../../dist/focus-trap-react');
+
+const container = document.getElementById('demo-containerelements');
+
+class DemoContainerElements extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      activeTrap: false,
+    };
+
+    this.mountTrap = this.mountTrap.bind(this);
+    this.unmountTrap = this.unmountTrap.bind(this);
+    this.setElementRef = this.setElementRef.bind(this);
+
+    this.elementRef1 = React.createRef();
+    this.elementRef2 = React.createRef();
+  }
+
+  mountTrap() {
+    this.setState({ activeTrap: true });
+  }
+
+  unmountTrap() {
+    this.setState({ activeTrap: false });
+  }
+
+  setElementRef(refName) {
+    return (element) => {
+      if (!this[refName].current) {
+        this[refName].current = element;
+        this.forceUpdate();
+      }
+    };
+  }
+
+  render() {
+    const trap = this.state.activeTrap ? (
+      <FocusTrap
+        containerElements={[this.elementRef1.current, this.elementRef2.current]}
+        focusTrapOptions={{
+          onDeactivate: this.unmountTrap,
+          clickOutsideDeactivates: true,
+        }}
+      >
+        <div className="trap is-active">
+          <p ref={this.setElementRef('elementRef1')}>
+            Here is a focus trap <a href="#">with</a> <a href="#">some</a>
+            <a href="#">focusable</a> parts.
+          </p>
+          <p>
+            Here is <a href="#">something</a>.
+          </p>
+          <p ref={this.setElementRef('elementRef2')}>
+            Here is a another focus trap element. <a href="#">See</a>{' '}
+            <a href="#">how</a>
+            it <a href="#">works</a>.
+          </p>
+          <p>
+            <button onClick={this.unmountTrap}>deactivate trap</button>
+          </p>
+        </div>
+      </FocusTrap>
+    ) : (
+      false
+    );
+
+    return (
+      <div>
+        <p>
+          <button onClick={this.mountTrap}>activate trap</button>
+        </p>
+        {trap}
+      </div>
+    );
+  }
+}
+
+ReactDOM.render(<DemoContainerElements />, container);

--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -2,3 +2,4 @@ require('./demo-defaults');
 require('./demo-ffne');
 require('./demo-special-element');
 require('./demo-autofocus');
+require('./demo-containerelements');

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,7 @@ declare namespace FocusTrap {
     active?: boolean;
     paused?: boolean;
     focusTrapOptions?: FocusTrapOptions;
+    containerElements?: Array<HTMLElement | string>;
   }
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,7 @@ declare namespace FocusTrap {
     active?: boolean;
     paused?: boolean;
     focusTrapOptions?: FocusTrapOptions;
-    containerElements?: Array<HTMLElement | string>;
+    containerElements?: Array<HTMLElement>;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "typescript": "^4.0.5"
   },
   "dependencies": {
-    "focus-trap": "^6.1.4"
+    "focus-trap": "^6.2.0"
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -124,7 +124,7 @@ class FocusTrap extends React.Component {
     }
   }
 
-  setFocusTrapElement = (elements) => {
+  setFocusTrapElements = (elements) => {
     this.focusTrapElements = elements;
   };
 
@@ -141,7 +141,7 @@ class FocusTrap extends React.Component {
       }
 
       const elements = containerElements ? containerElements : [element];
-      this.setFocusTrapElement(elements);
+      this.setFocusTrapElements(elements);
     };
 
     const childWithRef = React.cloneElement(child, {
@@ -182,9 +182,7 @@ FocusTrap.propTypes = {
     allowOutsideClick: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
     preventScroll: PropTypes.bool,
   }),
-  containerElements: PropTypes.arrayOf(
-    PropTypes.oneOfType([PropTypes.instanceOf(ElementType), PropTypes.string])
-  ),
+  containerElements: PropTypes.arrayOf(PropTypes.instanceOf(ElementType)),
   children: PropTypes.oneOfType([
     PropTypes.element, // React element
     PropTypes.instanceOf(ElementType), // DOM element

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -57,43 +57,62 @@ class FocusTrap extends React.Component {
     }
   }
 
-  componentDidMount() {
-    const focusTrapElementDOMNode = ReactDOM.findDOMNode(this.focusTrapElement);
+  setupFocusTrap() {
+    if (!this.focusTrap) {
+      const focusTrapElementDOMNodes = this.focusTrapElements.map(
+        ReactDOM.findDOMNode
+      );
 
-    // eslint-disable-next-line react/prop-types -- _createFocusTrap is an internal prop
-    this.focusTrap = this.props._createFocusTrap(
-      focusTrapElementDOMNode,
-      this.tailoredFocusTrapOptions
-    );
+      const nodesExist = focusTrapElementDOMNodes.some(Boolean);
+      if (nodesExist) {
+        // eslint-disable-next-line react/prop-types -- _createFocusTrap is an internal prop
+        this.focusTrap = this.props._createFocusTrap(
+          focusTrapElementDOMNodes,
+          this.tailoredFocusTrapOptions
+        );
 
-    if (this.props.active) {
-      this.focusTrap.activate();
-    }
+        if (this.props.active) {
+          this.focusTrap.activate();
+        }
 
-    if (this.props.paused) {
-      this.focusTrap.pause();
+        if (this.props.paused) {
+          this.focusTrap.pause();
+        }
+      }
     }
   }
 
+  componentDidMount() {
+    this.setupFocusTrap();
+  }
+
   componentDidUpdate(prevProps) {
-    if (prevProps.active && !this.props.active) {
-      // NOTE: we never let the trap return the focus since we do that ourselves
-      this.focusTrap.deactivate({ returnFocus: false });
-      if (this.returnFocusOnDeactivate) {
-        this.returnFocus();
+    this.setupFocusTrap();
+
+    if (this.focusTrap) {
+      if (prevProps.containerElements !== this.props.containerElements) {
+        this.focusTrap.updateContainerElements(this.props.containerElements);
       }
-      return; // un/pause does nothing on an inactive trap
-    }
 
-    if (!prevProps.active && this.props.active) {
-      this.updatePreviousElement();
-      this.focusTrap.activate();
-    }
+      if (prevProps.active && !this.props.active) {
+        // NOTE: we never let the trap return the focus since we do that ourselves
+        this.focusTrap.deactivate({ returnFocus: false });
+        if (this.returnFocusOnDeactivate) {
+          this.returnFocus();
+        }
+        return; // un/pause does nothing on an inactive trap
+      }
 
-    if (prevProps.paused && !this.props.paused) {
-      this.focusTrap.unpause();
-    } else if (!prevProps.paused && this.props.paused) {
-      this.focusTrap.pause();
+      if (!prevProps.active && this.props.active) {
+        this.updatePreviousElement();
+        this.focusTrap.activate();
+      }
+
+      if (prevProps.paused && !this.props.paused) {
+        this.focusTrap.unpause();
+      } else if (!prevProps.paused && this.props.paused) {
+        this.focusTrap.pause();
+      }
     }
   }
 
@@ -105,20 +124,24 @@ class FocusTrap extends React.Component {
     }
   }
 
-  setFocusTrapElement = (element) => {
-    this.focusTrapElement = element;
+  setFocusTrapElement = (elements) => {
+    this.focusTrapElements = elements;
   };
 
   render() {
     const child = React.Children.only(this.props.children);
 
     const composedRefCallback = (element) => {
-      this.setFocusTrapElement(element);
+      const { containerElements } = this.props;
+
       if (typeof child.ref === 'function') {
         child.ref(element);
       } else if (child.ref) {
         child.ref.current = element;
       }
+
+      const elements = containerElements ? containerElements : [element];
+      this.setFocusTrapElement(elements);
     };
 
     const childWithRef = React.cloneElement(child, {
@@ -159,6 +182,9 @@ FocusTrap.propTypes = {
     allowOutsideClick: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
     preventScroll: PropTypes.bool,
   }),
+  containerElements: PropTypes.arrayOf(
+    PropTypes.oneOfType([PropTypes.instanceOf(ElementType), PropTypes.string])
+  ),
   children: PropTypes.oneOfType([
     PropTypes.element, // React element
     PropTypes.instanceOf(ElementType), // DOM element

--- a/test/activation.test.js
+++ b/test/activation.test.js
@@ -14,6 +14,7 @@ describe('activation', () => {
     activate: jest.fn(),
     deactivate: jest.fn(),
     pause: jest.fn(),
+    updateContainerElements: jest.fn(),
   };
   let mockCreateFocusTrap;
 
@@ -41,12 +42,47 @@ describe('activation', () => {
 
     expect(mockCreateFocusTrap).toHaveBeenCalledTimes(1);
     expect(mockCreateFocusTrap).toHaveBeenCalledWith(
-      ReactDOM.findDOMNode(trap),
+      [ReactDOM.findDOMNode(trap)],
       {
         onDeactivate: noop,
         returnFocusOnDeactivate: false,
       }
     );
+  });
+
+  test('activation with containerElements props in new props', () => {
+    const div1 = document.createElement('div');
+    const div2 = document.createElement('div');
+
+    ReactDOM.render(
+      <FocusTrap
+        _createFocusTrap={mockCreateFocusTrap}
+        containerElements={[]}
+        focusTrapOptions={{ onDeactivate: noop }}
+      >
+        <button>something special</button>
+      </FocusTrap>,
+      domContainer
+    );
+
+    expect(mockCreateFocusTrap).not.toHaveBeenCalled();
+
+    ReactDOM.render(
+      <FocusTrap
+        _createFocusTrap={mockCreateFocusTrap}
+        containerElements={[div1, div2]}
+        focusTrapOptions={{ onDeactivate: noop }}
+      >
+        <button>something special</button>
+      </FocusTrap>,
+      domContainer
+    );
+
+    expect(mockCreateFocusTrap).toHaveBeenCalledTimes(1);
+    expect(mockFocusTrap.updateContainerElements).toHaveBeenCalledWith([
+      div1,
+      div2,
+    ]);
   });
 
   test('activation with initialFocus as selector', () => {
@@ -68,7 +104,7 @@ describe('activation', () => {
 
     expect(mockCreateFocusTrap).toHaveBeenCalledTimes(1);
     expect(mockCreateFocusTrap).toHaveBeenCalledWith(
-      ReactDOM.findDOMNode(trap),
+      [ReactDOM.findDOMNode(trap)],
       {
         onDeactivate: noop,
         initialFocus: '#initial-focusee',
@@ -125,7 +161,7 @@ describe('activation', () => {
 
     expect(mockCreateFocusTrap).toHaveBeenCalledTimes(1);
     expect(mockCreateFocusTrap).toHaveBeenCalledWith(
-      ReactDOM.findDOMNode(zone.refs.trap),
+      [ReactDOM.findDOMNode(zone.refs.trap)],
       {
         onDeactivate: noop,
         returnFocusOnDeactivate: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4038,10 +4038,10 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
-focus-trap@^6.1.4:
-  version "6.1.4"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.1.4.tgz#6297a9f0f45a84377b60e9a8c0d1f8a5b98d94d2"
-  integrity sha512-jgNc+O8UkGsUpdhNXkyonwlw4i707+ESAWv1vCbyd8+29db5/Wv1BkJImDczfEWMu9O635FvM5ABOjeyqNQpEQ==
+focus-trap@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.2.0.tgz#ff8aa4bef1f4c47f6fee3fdcee71474771cab374"
+  integrity sha512-CO9ovKkTdoo4eKQJ2/nLIsDyCwEDKfbeuW27PqFJZQoPzVwrbDj6RhPvVxPbj2kzOrWN7sVEMeIVzeqSXFd15g==
   dependencies:
     tabbable "^5.1.3"
 


### PR DESCRIPTION
This is WIP until the first PR is merged: https://github.com/focus-trap/focus-trap/pull/217, and the dependency of focus-trap is updated.

###  Features and Bug Fixes

- [x] Unit test coverage added/updated.
- [x] E2E test coverage added/updated.
- [x] Prop-types added/updated.
- [x] Typings added/updated.
- [x] README updated (API changes, instructions, etc.).
- [x] Changes to dependencies explained.
- [x] Changeset added (run `yarn changeset` locally to add one, follow prompts).

This is part 2 of the PR https://github.com/focus-trap/focus-trap/pull/217

---------------
Demo 1
![demo2](https://user-images.githubusercontent.com/5473697/99108180-35a80480-25a4-11eb-91f9-27324961044b.gif)

Demo 2
![demo](https://user-images.githubusercontent.com/5473697/99108183-36409b00-25a4-11eb-863e-9a26ba304df2.gif)