### PR TITLE
Fixing a bug where the focus trap may not have been set before it is …

### DIFF
--- a/.changeset/hip-bottles-turn.md
+++ b/.changeset/hip-bottles-turn.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': patch
+---
+
+Fixing a bug where the focus trap may not have been set before it is unmounted #184

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -118,7 +118,10 @@ class FocusTrap extends React.Component {
 
   componentWillUnmount() {
     // NOTE: we never let the trap return the focus since we do that ourselves
-    this.focusTrap.deactivate({ returnFocus: false });
+    if (this.focusTrap) {
+      this.focusTrap.deactivate({ returnFocus: false });
+    }
+
     if (this.returnFocusOnDeactivate) {
       this.returnFocus();
     }


### PR DESCRIPTION
Fixing a bug where the focus trap may not have been set before it is unmounted.

I found this when running our unit tests.  Imagine this scenario.

Imagine this scenario:

```js
const Example = () => {
  const [isOpen, setIsOpen] = useState(false)
  return  (<FocusTrap
      active={isOpen}
      containerElements={[ref1.current, ref2.current]}>
    {isOpen && (
      <>
        <div ref={ref1}/>
        <div ref={ref2}/>
        ....blah blah blah
      </>
    )}
  </FocusTrap>
  )
}
```

In this scenario, let's say that ref1.current and ref2.current don't get initialized before this component is unmounting.  Because of that, it will try to deactivate a focusTrap that was never instantiated in the first place.  See this line: https://github.com/focus-trap/focus-trap-react/blob/master/src/focus-trap-react.js#L67

This will fix an error that looks like this:

```
TypeError: Cannot read property 'deactivate' of undefined

      at FocusTrap.componentWillUnmount (node_modules/focus-trap-react/dist/focus-trap-react.js:171:24)

```

Sorry that I didn't have this in the original PR.  I wasn't expecting that.  I tested out the UI, but never ran the unit tests in our consuming code.