### PR TITLE
Make it possible to have `<FocusTrap />` without children

### DIFF
--- a/.changeset/slow-adults-rhyme.md
+++ b/.changeset/slow-adults-rhyme.md
@@ -1,0 +1,7 @@
+---
+'focus-trap-react': minor
+---
+
+- Remove the need for a child in `<FocusTrap />` when `containerElements` is used. The child was already being ignored anyway (when `containerElements` is used; if the prop is not used, then a single child is still required).
+- Update the typings related to the `children` prop to make it optional. Prop-types already had `children` as optional, however the use of `React.Children.only()` in all cases was still forcing the presence of a single child. That's no longer the case.
+- Add additional notes about the use of the `containerElements` prop in the documentation.

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ If passed in, these elements will be used as the boundaries for the focus-trap, 
 
 If `containerElements` is subsequently updated (i.e. after the trap has been created) to an empty array (or an array of falsy values like `[null, null]`), the trap will still be active, but the TAB key will do nothing because the trap will not contain any tabbable groups of nodes. At this point, the trap can either be deactivated manually or by unmounting, or an updated set of elements can be given to `containerElements` to resume use of the TAB key.
 
+Using `containerElements` does require the use of React refs which, by nature, will require at least one state update in order to get the resolved elements into the prop, resulting in at least one additional render. In the normal case, this is likely more than acceptable, but if you really want to optimize things, then you could consider [using focus-trap directly](https://codesandbox.io/s/focus-trapreact-containerelements-demos-v5ydi) (see `Trap2.js`).
+
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -165,7 +165,11 @@ If you would like to pause or unpause the focus trap (see [`focus-trap`'s docume
 
 Type: `Array of HTMLElement`, optional
 
-If passed in, these elements will be used as the boundaries for the focus-trap, instead of the child.  These get passed as arguments to focus-trap's updateContainerElements method.
+If passed in, these elements will be used as the boundaries for the focus-trap, __instead of the child__.  These get passed as arguments to `focus-trap`'s `updateContainerElements()` method.
+
+> Note that when you use `containerElements`, the need for a child is eliminated as the child is __always__ ignored when the prop is specified, even if the prop is `[]` (an empty array). Also note that if the refs you're putting into the array like `containerElements={[ref1.current, ref2.current]}` and one or both refs aren't resolved yet, resulting in `[null, null]` for example, the trap will not get created. The array must contain at least one `HTMLElement` in order for the trap to get updated.
+
+If `containerElements` is subsequently updated (i.e. after the trap has been created) to an empty array (or an array of falsy values like `[null, null]`), the trap will still be active, but the TAB key will do nothing because the trap will not contain any tabbable groups of nodes. At this point, the trap can either be deactivated manually or by unmounting, or an updated set of elements can be given to `containerElements` to resume use of the TAB key.
 
 ## Contributing
 

--- a/cypress/integration/focus-trap-demo.spec.js
+++ b/cypress/integration/focus-trap-demo.spec.js
@@ -243,62 +243,124 @@ describe('<FocusTrap> component', () => {
   });
 
   describe('demo: containerElements prop', () => {
-    it('containerElements can be passed in and used as multiple boundaries to keep the focus within', () => {
-      cy.get('#demo-containerelements').as('testRoot');
+    describe('with child', () => {
+      it('containerElements can be passed in and used as multiple boundaries to keep the focus within', () => {
+        cy.get('#demo-containerelements').as('testRoot');
 
-      // activate trap
-      cy.get('@testRoot')
-        .findByRole('button', { name: 'activate trap' })
-        .as('lastlyFocusedElementBeforeTrapIsActivated')
-        .click();
+        // activate trap
+        cy.get('@testRoot')
+          .findByRole('button', { name: 'activate trap' })
+          .as('lastlyFocusedElementBeforeTrapIsActivated')
+          .click();
 
-      // 1st element should be focused
-      cy.get('@testRoot')
-        .findByRole('link', { name: 'with' })
-        .as('firstElementInTrap')
-        .should('be.focused');
+        // 1st element should be focused
+        cy.get('@testRoot')
+          .findByRole('link', { name: 'with' })
+          .as('firstElementInTrap')
+          .should('be.focused');
 
-      // trap is active(keep focus in trap by tabbing through the focus trap's tabbable elements)
-      cy.get('@firstElementInTrap')
-        .tab()
-        .should('have.text', 'some')
-        .should('be.focused')
-        .tab()
-        .should('have.text', 'focusable')
-        .should('be.focused')
-        .tab()
-        .should('have.text', 'See')
-        .should('be.focused')
-        .tab()
-        .should('have.text', 'how')
-        .should('be.focused')
-        .tab()
-        .should('have.text', 'works')
-        .should('be.focused')
-        .tab()
-        .should('have.text', 'with')
-        .should('be.focused')
-        .tab({ shift: true })
-        .should('have.text', 'works')
-        .should('be.focused')
-        .tab({ shift: true })
-        .should('have.text', 'how')
-        .should('be.focused')
-        .tab({ shift: true })
-        .should('have.text', 'See')
-        .should('be.focused')
-        .tab({ shift: true })
-        .should('have.text', 'focusable')
-        .should('be.focused')
-        .tab({ shift: true })
-        .should('have.text', 'some')
-        .should('be.focused')
-        .tab({ shift: true })
-        .should('have.text', 'with')
-        .should('be.focused')
-        .tab({ shift: true })
-        .should('have.text', 'works')
-        .should('be.focused');
+        // trap is active(keep focus in trap by tabbing through the focus trap's tabbable elements)
+        cy.get('@firstElementInTrap')
+          .tab()
+          .should('have.text', 'some')
+          .should('be.focused')
+          .tab()
+          .should('have.text', 'focusable')
+          .should('be.focused')
+          .tab()
+          .should('have.text', 'See')
+          .should('be.focused')
+          .tab()
+          .should('have.text', 'how')
+          .should('be.focused')
+          .tab()
+          .should('have.text', 'works')
+          .should('be.focused')
+          .tab()
+          .should('have.text', 'with')
+          .should('be.focused')
+          .tab({ shift: true })
+          .should('have.text', 'works')
+          .should('be.focused')
+          .tab({ shift: true })
+          .should('have.text', 'how')
+          .should('be.focused')
+          .tab({ shift: true })
+          .should('have.text', 'See')
+          .should('be.focused')
+          .tab({ shift: true })
+          .should('have.text', 'focusable')
+          .should('be.focused')
+          .tab({ shift: true })
+          .should('have.text', 'some')
+          .should('be.focused')
+          .tab({ shift: true })
+          .should('have.text', 'with')
+          .should('be.focused')
+          .tab({ shift: true })
+          .should('have.text', 'works')
+          .should('be.focused');
+      });
+    });
+
+    describe('without child', () => {
+      it('containerElements can be passed in and used as multiple boundaries to keep the focus within', () => {
+        cy.get('#demo-containerelements-childless').as('testRoot');
+
+        // activate trap
+        cy.get('@testRoot')
+          .findByRole('button', { name: 'activate trap' })
+          .as('lastlyFocusedElementBeforeTrapIsActivated')
+          .click();
+
+        // 1st element should be focused
+        cy.get('@testRoot')
+          .findByRole('link', { name: 'with' })
+          .as('firstElementInTrap')
+          .should('be.focused');
+
+        // trap is active(keep focus in trap by tabbing through the focus trap's tabbable elements)
+        cy.get('@firstElementInTrap')
+          .tab()
+          .should('have.text', 'some')
+          .should('be.focused')
+          .tab()
+          .should('have.text', 'focusable')
+          .should('be.focused')
+          .tab()
+          .should('have.text', 'See')
+          .should('be.focused')
+          .tab()
+          .should('have.text', 'how')
+          .should('be.focused')
+          .tab()
+          .should('have.text', 'works')
+          .should('be.focused')
+          .tab()
+          .should('have.text', 'with')
+          .should('be.focused')
+          .tab({ shift: true })
+          .should('have.text', 'works')
+          .should('be.focused')
+          .tab({ shift: true })
+          .should('have.text', 'how')
+          .should('be.focused')
+          .tab({ shift: true })
+          .should('have.text', 'See')
+          .should('be.focused')
+          .tab({ shift: true })
+          .should('have.text', 'focusable')
+          .should('be.focused')
+          .tab({ shift: true })
+          .should('have.text', 'some')
+          .should('be.focused')
+          .tab({ shift: true })
+          .should('have.text', 'with')
+          .should('be.focused')
+          .tab({ shift: true })
+          .should('have.text', 'works')
+          .should('be.focused');
+      });
     });
   });
 });

--- a/demo/index.html
+++ b/demo/index.html
@@ -59,9 +59,18 @@
 
   <h2>demo containerElements</h2>
   <p>
-    You may pass in an array prop `containerElements` that contains nodes to trap focus within, which if passed will be used instead of the direct child.
+    You may pass in an array prop <code>containerElements</code> that contains nodes to trap focus within, which if passed will be used instead of the direct child. The direct child, if any, <strong>will be ignored by the trap</strong> (unless also given as an element in <code>containerElements</code>).
   </p>
   <div id="demo-containerelements"></div>
+
+  <h2>demo containerElements (no child)</h2>
+  <p>
+    Slight <em>underlying</em> difference from the previous "containerElements" demo in that the
+    focus trap element is not given a child: <code>&lt;FocusTrap containerElements={[...]} /&gt;</code>.
+    The result is the same, but this further reinforces the fact that when <code>containerElements</code> is
+    used, the child is not considered, and therefore not even necessary.
+  </p>
+  <div id="demo-containerelements-childless"></div>
 
   <p>
     <span style="font-size:2em;vertical-align:middle;">☜</span>

--- a/demo/js/demo-containerelements-childless.js
+++ b/demo/js/demo-containerelements-childless.js
@@ -2,9 +2,9 @@ const React = require('react');
 const ReactDOM = require('react-dom');
 const FocusTrap = require('../../dist/focus-trap-react');
 
-const container = document.getElementById('demo-containerelements');
+const container = document.getElementById('demo-containerelements-childless');
 
-class DemoContainerElements extends React.Component {
+class DemoContainerElementsChildless extends React.Component {
   constructor(props) {
     super(props);
 
@@ -39,16 +39,20 @@ class DemoContainerElements extends React.Component {
 
   render() {
     const trap = this.state.activeTrap ? (
-      <FocusTrap
-        containerElements={[this.element1, this.element2]}
-        focusTrapOptions={{
-          onDeactivate: this.unmountTrap,
-          allowOutsideClick(event) {
-            return event.target.id === 'demo-containerelements-deactivate';
-          },
-        }}
-      >
-        {/* NOTE: child is IGNORED in favor of `containerElements` */}
+      <>
+        <FocusTrap
+          containerElements={[this.element1, this.element2]}
+          focusTrapOptions={{
+            onDeactivate: this.unmountTrap,
+            allowOutsideClick(event) {
+              return (
+                event.target.id ===
+                'demo-containerelements-childless-deactivate'
+              );
+            },
+          }}
+        />
+
         <div className="trap is-active">
           <p ref={this.setElementRef('element1')}>
             Here is a focus trap <a href="#">with</a> <a href="#">some</a>
@@ -64,14 +68,14 @@ class DemoContainerElements extends React.Component {
           </p>
           <p>
             <button
-              id="demo-containerelements-deactivate"
+              id="demo-containerelements-childless-deactivate"
               onClick={this.unmountTrap}
             >
               deactivate trap
             </button>
           </p>
         </div>
-      </FocusTrap>
+      </>
     ) : (
       false
     );
@@ -87,4 +91,4 @@ class DemoContainerElements extends React.Component {
   }
 }
 
-ReactDOM.render(<DemoContainerElements />, container);
+ReactDOM.render(<DemoContainerElementsChildless />, container);

--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -3,3 +3,4 @@ require('./demo-ffne');
 require('./demo-special-element');
 require('./demo-autofocus');
 require('./demo-containerelements');
+require('./demo-containerelements-childless');

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,7 +5,7 @@ export = FocusTrap;
 
 declare namespace FocusTrap {
   export interface Props extends React.AllHTMLAttributes<any> {
-    children: React.ReactNode;
+    children?: React.ReactNode;
     active?: boolean;
     paused?: boolean;
     focusTrapOptions?: FocusTrapOptions;

--- a/test/activation.test.js
+++ b/test/activation.test.js
@@ -79,10 +79,13 @@ describe('activation', () => {
     );
 
     expect(mockCreateFocusTrap).toHaveBeenCalledTimes(1);
-    expect(mockFocusTrap.updateContainerElements).toHaveBeenCalledWith([
-      div1,
-      div2,
-    ]);
+
+    // because we gave the trap 2 valid elements on first render, the trap is
+    //  created immediately with the two elements and there's no subsequent
+    //  update of the trap's container elements that's necessary
+    // NOTE: we test the case of subsequent updates to containerElements in the
+    //  e2e tests
+    expect(mockFocusTrap.updateContainerElements).not.toHaveBeenCalled();
   });
 
   test('activation with initialFocus as selector', () => {

--- a/test/dom.test.js
+++ b/test/dom.test.js
@@ -73,12 +73,12 @@ describe('dom', () => {
     expect(trapNode.firstChild.innerHTML).toBe('something special');
   });
 
-  test('FocusTrap throws with no child provided to it', () => {
+  test('FocusTrap allows having no child', () => {
     expect(() =>
       TestUtils.renderIntoDocument(
         <FocusTrap _createFocusTrap={mockCreateFocusTrap} />
       )
-    ).toThrowError('expected to receive a single React element child');
+    ).not.toThrowError('expected to receive a single React element child');
   });
 
   test('FocusTrap throws with a plain text child provided to it', () => {


### PR DESCRIPTION
Only when `containerElements` are used.

###  Features and Bug Fixes

- [x] Unit test coverage added/updated.
- [x] E2E test coverage added/updated.
- [x] Prop-types added/updated.
- [x] Typings added/updated.
- [x] README updated (API changes, instructions, etc.).
- [x] Changeset added (run `yarn changeset` locally to add one, follow prompts).
