### PR TITLE
upgrade e2e and enable firefox

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,18 +52,17 @@ jobs:
         run: yarn build
   e2e:
     runs-on: ubuntu-latest
-    container: cypress/included:5.0.0
     strategy:
       matrix:
-        browser: [chrome] # cypress executable says 'Browser: 'firefox' was not found on your system or is not supported by Cypress.' seems to be defect
+        browser: [chrome, firefox]
+    container:
+      image: cypress/included:6.0.1
+      options: --user 1001
     env:
       CYPRESS_BROWSER: ${{ matrix.browser }}
     steps:
-      - name: Checkout 🛎
-        uses: actions/checkout@master
-
-      - name: Install dependencies 📦
-        uses: bahmutov/npm-install@v1
-
-      - name: Run tests 🧪
-        run: yarn test:cypress-ci
+      - uses: actions/checkout@v1
+      - uses: cypress-io/github-action@v2.6.1
+        with:
+          start: yarn start
+          browser: ${{ matrix.browser }}


### PR DESCRIPTION
###  Features and Bug Fixes

~- [ ] Issue being fixed is referenced.~
~- [ ] Unit test coverage added/updated.~
~- [ ] E2E test coverage added/updated.~
~- [ ] Prop-types added/updated.~
~- [ ] Typings added/updated.~
~- [ ] README updated (API changes, instructions, etc.).~
~- [ ] Changes to dependencies explained.~
~- [ ] Changeset added (run `yarn changeset` locally to add one, follow prompts).~

### Tooling

- [x] Issue being fixed is referenced.
- [x] Changes to dependencies explained.
~- [ ] README instructions updated.~
- [x] A Changeset is __not__ added.

### DONE
- This is fixing cypress firefox issue on git action https://github.com/cypress-io/cypress-docker-images/issues/363 and also #104 
- Cypress container is updated to keep currency with `package.json` `devDependencies`
