### PR TITLE
docs: adds a11y improvements to the demo

### DIFF
--- a/cypress/integration/focus-trap-demo.spec.js
+++ b/cypress/integration/focus-trap-demo.spec.js
@@ -19,7 +19,7 @@ describe('<FocusTrap> component', () => {
 
       // activate trap
       cy.get('@testRoot')
-        .findByRole('button', { name: 'activate trap' })
+        .findByRole('button', { name: "activate trap for 'defaults' demo" })
         .as('lastlyFocusedElementBeforeTrapIsActivated')
         .click();
 
@@ -52,7 +52,7 @@ describe('<FocusTrap> component', () => {
 
       // trap can be deactivated and return focus to lastly focused element before trap is activated
       cy.get('@testRoot')
-        .findByRole('button', { name: 'deactivate trap' })
+        .findByRole('button', { name: "deactivate trap for 'defaults' demo" })
         .click();
       cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should('have.focus');
 
@@ -73,12 +73,14 @@ describe('<FocusTrap> component', () => {
 
       // activate trap
       cy.get('@testRoot')
-        .findByRole('button', { name: 'activate trap' })
+        .findByRole('button', {
+          name: "activate trap for 'first focus, no escape' demo",
+        })
         .click();
 
       // instead of next tab-order element being focused, element specified should be focused
       cy.get('@testRoot')
-        .findByRole('textbox', { name: 'Initially focused input' })
+        .findByRole('textbox', { name: 'Initially focused input:' })
         .as('focusedEl')
         .should('be.focused');
 
@@ -91,13 +93,15 @@ describe('<FocusTrap> component', () => {
 
       // activate trap
       cy.get('@testRoot')
-        .findByRole('button', { name: 'activate trap' })
+        .findByRole('button', {
+          name: "activate trap for 'first focus, no escape' demo",
+        })
         .as('lastlyFocusedElementBeforeTrapIsActivated')
         .click();
 
       // trying deactivate trap by ESC
       cy.get('@testRoot')
-        .findByRole('textbox', { name: 'Initially focused input' })
+        .findByRole('textbox', { name: 'Initially focused input:' })
         .as('trapChild')
         .focus()
         .type('{esc}');
@@ -110,7 +114,9 @@ describe('<FocusTrap> component', () => {
 
       // click on deactivate trap button to deactivate trap
       cy.get('@testRoot')
-        .findByRole('button', { name: 'deactivate trap' })
+        .findByRole('button', {
+          name: "deactivate trap for 'first focus, no escape' demo",
+        })
         .click();
       cy.get('@trapChild').should('not.exist');
       cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should('be.focused');
@@ -152,14 +158,18 @@ describe('<FocusTrap> component', () => {
 
       // activate trap
       cy.get('@testRoot')
-        .findByRole('button', { name: 'activate trap' })
+        .findByRole('button', {
+          name: "activate trap for 'special element' demo",
+        })
         .as('lastlyFocusedElementBeforeTrapIsActivated')
         .click();
 
       verifyFocusTrapped();
 
       cy.get('@testRoot')
-        .findByRole('button', { name: 'deactivate trap' })
+        .findByRole('button', {
+          name: "deactivate trap for 'special element' demo",
+        })
         .as('trapChild')
         .click();
 
@@ -174,14 +184,18 @@ describe('<FocusTrap> component', () => {
 
       // activate trap
       cy.get('@testRoot')
-        .findByRole('button', { name: 'activate trap' })
+        .findByRole('button', {
+          name: "activate trap for 'special element' demo",
+        })
         .as('lastlyFocusedElementBeforeTrapIsActivated')
         .click();
 
       verifyFocusTrapped();
 
       cy.get('@testRoot')
-        .findByRole('button', { name: 'deactivate trap' })
+        .findByRole('button', {
+          name: "deactivate trap for 'special element' demo",
+        })
         .as('trapChild')
         .type('{esc}');
 
@@ -196,14 +210,18 @@ describe('<FocusTrap> component', () => {
 
       // activate trap
       cy.get('@testRoot')
-        .findByRole('button', { name: 'activate trap' })
+        .findByRole('button', {
+          name: "activate trap for 'special element' demo",
+        })
         .as('lastlyFocusedElementBeforeTrapIsActivated')
         .click();
 
       verifyFocusTrapped();
 
       cy.get('@testRoot')
-        .findByRole('button', { name: 'deactivate trap' })
+        .findByRole('button', {
+          name: "deactivate trap for 'special element' demo",
+        })
         .as('trapChild');
 
       // click outside to deactivate trap and also click carries through
@@ -231,7 +249,7 @@ describe('<FocusTrap> component', () => {
 
       // activate trap
       cy.get('@testRoot')
-        .findByRole('button', { name: 'activate trap' })
+        .findByRole('button', { name: "activate trap for 'autofocus' demo" })
         .click();
 
       // element with "autofocus" attribute is focused
@@ -249,7 +267,9 @@ describe('<FocusTrap> component', () => {
 
         // activate trap
         cy.get('@testRoot')
-          .findByRole('button', { name: 'activate trap' })
+          .findByRole('button', {
+            name: "activate trap for 'containerElements' demo",
+          })
           .as('lastlyFocusedElementBeforeTrapIsActivated')
           .click();
 
@@ -309,7 +329,9 @@ describe('<FocusTrap> component', () => {
 
         // activate trap
         cy.get('@testRoot')
-          .findByRole('button', { name: 'activate trap' })
+          .findByRole('button', {
+            name: "activate trap for 'containerElements (no child)' demo",
+          })
           .as('lastlyFocusedElementBeforeTrapIsActivated')
           .click();
 

--- a/cypress/integration/focus-trap-demo.spec.js
+++ b/cypress/integration/focus-trap-demo.spec.js
@@ -19,7 +19,7 @@ describe('<FocusTrap> component', () => {
 
       // activate trap
       cy.get('@testRoot')
-        .findByRole('button', { name: "activate trap for 'defaults' demo" })
+        .findByRole('button', { name: /^activate trap/ })
         .as('lastlyFocusedElementBeforeTrapIsActivated')
         .click();
 
@@ -52,7 +52,7 @@ describe('<FocusTrap> component', () => {
 
       // trap can be deactivated and return focus to lastly focused element before trap is activated
       cy.get('@testRoot')
-        .findByRole('button', { name: "deactivate trap for 'defaults' demo" })
+        .findByRole('button', { name: /^deactivate trap/ })
         .click();
       cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should('have.focus');
 
@@ -73,9 +73,7 @@ describe('<FocusTrap> component', () => {
 
       // activate trap
       cy.get('@testRoot')
-        .findByRole('button', {
-          name: "activate trap for 'first focus, no escape' demo",
-        })
+        .findByRole('button', { name: /^activate trap/ })
         .click();
 
       // instead of next tab-order element being focused, element specified should be focused
@@ -93,9 +91,7 @@ describe('<FocusTrap> component', () => {
 
       // activate trap
       cy.get('@testRoot')
-        .findByRole('button', {
-          name: "activate trap for 'first focus, no escape' demo",
-        })
+        .findByRole('button', { name: /^activate trap/ })
         .as('lastlyFocusedElementBeforeTrapIsActivated')
         .click();
 
@@ -114,9 +110,7 @@ describe('<FocusTrap> component', () => {
 
       // click on deactivate trap button to deactivate trap
       cy.get('@testRoot')
-        .findByRole('button', {
-          name: "deactivate trap for 'first focus, no escape' demo",
-        })
+        .findByRole('button', { name: /^deactivate trap/ })
         .click();
       cy.get('@trapChild').should('not.exist');
       cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should('be.focused');
@@ -158,18 +152,14 @@ describe('<FocusTrap> component', () => {
 
       // activate trap
       cy.get('@testRoot')
-        .findByRole('button', {
-          name: "activate trap for 'special element' demo",
-        })
+        .findByRole('button', { name: /^activate trap/ })
         .as('lastlyFocusedElementBeforeTrapIsActivated')
         .click();
 
       verifyFocusTrapped();
 
       cy.get('@testRoot')
-        .findByRole('button', {
-          name: "deactivate trap for 'special element' demo",
-        })
+        .findByRole('button', { name: /^deactivate trap/ })
         .as('trapChild')
         .click();
 
@@ -184,18 +174,14 @@ describe('<FocusTrap> component', () => {
 
       // activate trap
       cy.get('@testRoot')
-        .findByRole('button', {
-          name: "activate trap for 'special element' demo",
-        })
+        .findByRole('button', { name: /^activate trap/ })
         .as('lastlyFocusedElementBeforeTrapIsActivated')
         .click();
 
       verifyFocusTrapped();
 
       cy.get('@testRoot')
-        .findByRole('button', {
-          name: "deactivate trap for 'special element' demo",
-        })
+        .findByRole('button', { name: /^deactivate trap/ })
         .as('trapChild')
         .type('{esc}');
 
@@ -210,18 +196,14 @@ describe('<FocusTrap> component', () => {
 
       // activate trap
       cy.get('@testRoot')
-        .findByRole('button', {
-          name: "activate trap for 'special element' demo",
-        })
+        .findByRole('button', { name: /^activate trap/ })
         .as('lastlyFocusedElementBeforeTrapIsActivated')
         .click();
 
       verifyFocusTrapped();
 
       cy.get('@testRoot')
-        .findByRole('button', {
-          name: "deactivate trap for 'special element' demo",
-        })
+        .findByRole('button', { name: /^deactivate trap/ })
         .as('trapChild');
 
       // click outside to deactivate trap and also click carries through
@@ -249,7 +231,7 @@ describe('<FocusTrap> component', () => {
 
       // activate trap
       cy.get('@testRoot')
-        .findByRole('button', { name: "activate trap for 'autofocus' demo" })
+        .findByRole('button', { name: /^activate trap/ })
         .click();
 
       // element with "autofocus" attribute is focused
@@ -267,9 +249,7 @@ describe('<FocusTrap> component', () => {
 
         // activate trap
         cy.get('@testRoot')
-          .findByRole('button', {
-            name: "activate trap for 'containerElements' demo",
-          })
+          .findByRole('button', { name: /^activate trap/ })
           .as('lastlyFocusedElementBeforeTrapIsActivated')
           .click();
 
@@ -329,9 +309,7 @@ describe('<FocusTrap> component', () => {
 
         // activate trap
         cy.get('@testRoot')
-          .findByRole('button', {
-            name: "activate trap for 'containerElements (no child)' demo",
-          })
+          .findByRole('button', { name: /^activate trap/ })
           .as('lastlyFocusedElementBeforeTrapIsActivated')
           .click();
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -5,78 +5,76 @@
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>focus-trap-react demo</title>
-
   <link rel="stylesheet" href="style.css">
   <meta name="description" content="A demo of focus-trap-react">
-
 </head>
 <body>
-  <h1 tabindex="0">focus-trap-react demo</h1>
+  <main>
+    <h1 tabindex="0">focus-trap-react demo</h1>
+    <p>
+      <span aria-hidden="true" style="font-size:2em;vertical-align:middle;">☜</span>
+      <a href="https://github.com/focus-trap/focus-trap-react" style="vertical-align:middle;">Return to the repository</a>
+    </p>
 
-  <p>
-    <span style="font-size:2em;vertical-align:middle;">☜</span>
-    <a href="https://github.com/focus-trap/focus-trap-react" style="vertical-align:middle;">Return to the repository</a>
-  </p>
+    <h2>defaults</h2>
+    <p>
+      Default behavior: When this FocusTrap mounts (and activates), the first element in its tab order receives focus.
+    </p>
+    <div id="demo-defaults"></div>
 
-  <h2>defaults</h2>
-  <p>
-    Default behavior: When this FocusTrap mounts (and activates), the first element in its tab order receives focus.
-  </p>
-  <div id="demo-defaults"></div>
+    <h2>first focus, no escape</h2>
+    <p>
+      When this FocusTrap mounts (and activates), focus jumps to a specific, manually specified element.
+    </p>
+    <p>
+      Also, the Escape key does not deactivate this trap; you have to click the button to deactivate.
+    </p>
+    <div id="demo-ffne"></div>
 
-  <h2>first focus, no escape</h2>
-  <p>
-    When this FocusTrap mounts (and activates), focus jumps to a specific, manually specified element.
-  </p>
-  <p>
-    Also, the Escape key does not deactivate this trap: you have to click the button to deactivate.
-  </p>
-  <div id="demo-ffne"></div>
+    <h2>special element</h2>
+    <p>
+      Inspect this element and you'll see that it is not the default plain div,
+      but rather a section tag with an id, a class, inline styles, and an
+      arbitrary <code>data-</code>attribute.
+    </p>
+    <p>
+      Also, this FocusTrap activates and deactivates while staying mounted.
+    </p>
+    <p>
+      ALSO, when you click outside this FocusTrap, the trap deactivates and your click carries through.
+    </p>
+    <p>
+      Finally, focus should return to the "activate trap" button, whether you click the "deactivate trap"
+      button, or press the ESC key.
+    </p>
+    <div id="demo-special-element"></div>
 
-  <h2>special element</h2>
-  <p>
-    Inspect this element and you'll see that it is not the default plain div,
-    but rather a section tag with an id, a class, inline styles, and an
-    arbitrary <code>data-</code>attribute.
-  </p>
-  <p>
-    Also, this FocusTrap activates and deactivates while staying mounted.
-  </p>
-  <p>
-    ALSO, when you click outside this FocusTrap, the trap deactivates and your click carries through.
-  </p>
-  <p>
-    Finally, focus should return to the "activate trap" button, whether you click the "deactivate trap"
-    button, or press the ESC key.
-  </p>
-  <div id="demo-special-element"></div>
+    <h2>demo autofocus</h2>
+    <p>
+      The trap contains an input with the autofocus attribute.
+    </p>
+    <div id="demo-autofocus"></div>
 
-  <h2>demo autofocus</h2>
-  <p>
-    The trap contains an input with the autofocus attribute.
-  </p>
-  <div id="demo-autofocus"></div>
+    <h2>demo containerElements</h2>
+    <p>
+      You may pass in an array prop <code>containerElements</code> that contains nodes to trap focus within, which if passed will be used instead of the direct child. The direct child, if any, <strong>will be ignored by the trap</strong> (unless also given as an element in <code>containerElements</code>).
+    </p>
+    <div id="demo-containerelements"></div>
 
-  <h2>demo containerElements</h2>
-  <p>
-    You may pass in an array prop <code>containerElements</code> that contains nodes to trap focus within, which if passed will be used instead of the direct child. The direct child, if any, <strong>will be ignored by the trap</strong> (unless also given as an element in <code>containerElements</code>).
-  </p>
-  <div id="demo-containerelements"></div>
+    <h2>demo containerElements (no child)</h2>
+    <p>
+      Slight <em>underlying</em> difference from the previous "containerElements" demo in that the
+      focus trap element is not given a child: <code>&lt;FocusTrap containerElements={[...]} /&gt;</code>.
+      The result is the same, but this further reinforces the fact that when <code>containerElements</code> is
+      used, the child is not considered, and therefore not even necessary.
+    </p>
+    <div id="demo-containerelements-childless"></div>
 
-  <h2>demo containerElements (no child)</h2>
-  <p>
-    Slight <em>underlying</em> difference from the previous "containerElements" demo in that the
-    focus trap element is not given a child: <code>&lt;FocusTrap containerElements={[...]} /&gt;</code>.
-    The result is the same, but this further reinforces the fact that when <code>containerElements</code> is
-    used, the child is not considered, and therefore not even necessary.
-  </p>
-  <div id="demo-containerelements-childless"></div>
-
-  <p>
-    <span style="font-size:2em;vertical-align:middle;">☜</span>
-    <a href="https://github.com/focus-trap/focus-trap-react" style="vertical-align:middle;">Return to the repository</a>
-  </p>
-
+    <p>
+      <span aria-hidden="true" style="font-size:2em;vertical-align:middle;">☜</span>
+      <a href="https://github.com/focus-trap/focus-trap-react" style="vertical-align:middle;">Return to the repository</a>
+    </p>
+  </main>
   <script src="demo-bundle.js"></script>
 </body>
 </html>

--- a/demo/js/demo-autofocus.js
+++ b/demo/js/demo-autofocus.js
@@ -25,31 +25,44 @@ class DemoAutofocus extends React.Component {
   }
 
   render() {
-    const trap = this.state.activeTrap ? (
+    const trap = this.state.activeTrap && (
       <FocusTrap
         focusTrapOptions={{
           onDeactivate: this.unmountTrap,
         }}
       >
         <div className="trap is-active">
-          <button onClick={this.unmountTrap}>deactivate trap</button>
+          <button
+            onClick={this.unmountTrap}
+            aria-label="deactivate trap for 'autofocus' demo"
+          >
+            deactivate trap
+          </button>
           <div>
             <a href="#">Another focusable thing</a>
           </div>
           <div>
-            Autofocused input:
-            <input autoFocus={true} data-testid={'autofocus-el'} />
+            <label htmlFor="autofocused-input" style={{ marginRight: 10 }}>
+              Autofocused input:
+            </label>
+            <input
+              id="autofocused-input"
+              autoFocus
+              data-testid="autofocus-el"
+            />
           </div>
         </div>
       </FocusTrap>
-    ) : (
-      false
     );
 
     return (
       <div>
         <p>
-          <button key="button" onClick={this.mountTrap}>
+          <button
+            key="button"
+            onClick={this.mountTrap}
+            aria-label="activate trap for 'autofocus' demo"
+          >
             activate trap
           </button>
         </p>

--- a/demo/js/demo-containerelements-childless.js
+++ b/demo/js/demo-containerelements-childless.js
@@ -38,7 +38,7 @@ class DemoContainerElementsChildless extends React.Component {
   }
 
   render() {
-    const trap = this.state.activeTrap ? (
+    const trap = this.state.activeTrap && (
       <>
         <FocusTrap
           containerElements={[this.element1, this.element2]}
@@ -55,7 +55,7 @@ class DemoContainerElementsChildless extends React.Component {
 
         <div className="trap is-active">
           <p ref={this.setElementRef('element1')}>
-            Here is a focus trap <a href="#">with</a> <a href="#">some</a>
+            Here is a focus trap <a href="#">with</a> <a href="#">some</a>{' '}
             <a href="#">focusable</a> parts.
           </p>
           <p>
@@ -63,27 +63,30 @@ class DemoContainerElementsChildless extends React.Component {
           </p>
           <p ref={this.setElementRef('element2')}>
             Here is a another focus trap element. <a href="#">See</a>{' '}
-            <a href="#">how</a>
-            it <a href="#">works</a>.
+            <a href="#">how</a> it <a href="#">works</a>.
           </p>
           <p>
             <button
               id="demo-containerelements-childless-deactivate"
               onClick={this.unmountTrap}
+              aria-label="deactivate trap for 'containerElements (no child)' demo"
             >
               deactivate trap
             </button>
           </p>
         </div>
       </>
-    ) : (
-      false
     );
 
     return (
       <div>
         <p>
-          <button onClick={this.mountTrap}>activate trap</button>
+          <button
+            onClick={this.mountTrap}
+            aria-label="activate trap for 'containerElements (no child)' demo"
+          >
+            activate trap
+          </button>
         </p>
         {trap}
       </div>

--- a/demo/js/demo-containerelements.js
+++ b/demo/js/demo-containerelements.js
@@ -38,7 +38,7 @@ class DemoContainerElements extends React.Component {
   }
 
   render() {
-    const trap = this.state.activeTrap ? (
+    const trap = this.state.activeTrap && (
       <FocusTrap
         containerElements={[this.element1, this.element2]}
         focusTrapOptions={{
@@ -51,7 +51,7 @@ class DemoContainerElements extends React.Component {
         {/* NOTE: child is IGNORED in favor of `containerElements` */}
         <div className="trap is-active">
           <p ref={this.setElementRef('element1')}>
-            Here is a focus trap <a href="#">with</a> <a href="#">some</a>
+            Here is a focus trap <a href="#">with</a> <a href="#">some</a>{' '}
             <a href="#">focusable</a> parts.
           </p>
           <p>
@@ -59,27 +59,30 @@ class DemoContainerElements extends React.Component {
           </p>
           <p ref={this.setElementRef('element2')}>
             Here is a another focus trap element. <a href="#">See</a>{' '}
-            <a href="#">how</a>
-            it <a href="#">works</a>.
+            <a href="#">how</a> it <a href="#">works</a>.
           </p>
           <p>
             <button
               id="demo-containerelements-deactivate"
               onClick={this.unmountTrap}
+              aria-label="deactivate trap for 'containerElements' demo"
             >
               deactivate trap
             </button>
           </p>
         </div>
       </FocusTrap>
-    ) : (
-      false
     );
 
     return (
       <div>
         <p>
-          <button onClick={this.mountTrap}>activate trap</button>
+          <button
+            onClick={this.mountTrap}
+            aria-label="activate trap for 'containerElements' demo"
+          >
+            activate trap
+          </button>
         </p>
         {trap}
       </div>

--- a/demo/js/demo-defaults.js
+++ b/demo/js/demo-defaults.js
@@ -25,7 +25,7 @@ class DemoDefaults extends React.Component {
   }
 
   render() {
-    const trap = this.state.activeTrap ? (
+    const trap = this.state.activeTrap && (
       <FocusTrap
         focusTrapOptions={{
           onDeactivate: this.unmountTrap,
@@ -37,18 +37,26 @@ class DemoDefaults extends React.Component {
             <a href="#">focusable</a> parts.
           </p>
           <p>
-            <button onClick={this.unmountTrap}>deactivate trap</button>
+            <button
+              onClick={this.unmountTrap}
+              aria-label="deactivate trap for 'defaults' demo"
+            >
+              deactivate trap
+            </button>
           </p>
         </div>
       </FocusTrap>
-    ) : (
-      false
     );
 
     return (
       <div>
         <p>
-          <button onClick={this.mountTrap}>activate trap</button>
+          <button
+            onClick={this.mountTrap}
+            aria-label="activate trap for 'defaults' demo"
+          >
+            activate trap
+          </button>
         </p>
         {trap}
       </div>

--- a/demo/js/demo-ffne.js
+++ b/demo/js/demo-ffne.js
@@ -25,7 +25,7 @@ class DemoFfne extends React.Component {
   }
 
   render() {
-    const trap = this.state.activeTrap ? (
+    const trap = this.state.activeTrap && (
       <FocusTrap
         focusTrapOptions={{
           onDeactivate: this.unmountTrap,
@@ -40,23 +40,31 @@ class DemoFfne extends React.Component {
           </p>
           <p>
             <label htmlFor="focused-input" style={{ marginRight: 10 }}>
-              Initially focused input
+              Initially focused input:
             </label>
             <input id="focused-input" />
           </p>
           <p>
-            <button onClick={this.unmountTrap}>deactivate trap</button>
+            <button
+              onClick={this.unmountTrap}
+              aria-label="deactivate trap for 'first focus, no escape' demo"
+            >
+              deactivate trap
+            </button>
           </p>
         </div>
       </FocusTrap>
-    ) : (
-      false
     );
 
     return (
       <div>
         <p>
-          <button onClick={this.mountTrap}>activate trap</button>
+          <button
+            onClick={this.mountTrap}
+            aria-label="activate trap for 'first focus, no escape' demo"
+          >
+            activate trap
+          </button>
         </p>
         {trap}
       </div>

--- a/demo/js/demo-special-element.js
+++ b/demo/js/demo-special-element.js
@@ -39,7 +39,12 @@ class DemoSpecialElement extends React.Component {
     return (
       <div>
         <p>
-          <button onClick={this.mountTrap}>activate trap</button>
+          <button
+            onClick={this.mountTrap}
+            aria-label="activate trap for 'special element' demo"
+          >
+            activate trap
+          </button>
           <button onClick={this.updatePassThruMsg}>pass thru click</button>
           <span>{this.state.passThruMsg}</span>
         </p>
@@ -62,7 +67,12 @@ class DemoSpecialElement extends React.Component {
               <a href="#">focusable</a> parts.
             </p>
             <p>
-              <button onClick={this.unmountTrap}>deactivate trap</button>
+              <button
+                onClick={this.unmountTrap}
+                aria-label="deactivate trap for 'special element' demo"
+              >
+                deactivate trap
+              </button>
             </p>
           </section>
         </FocusTrap>


### PR DESCRIPTION
I've made several accessibility improvements to the demo site for semantic HTML correctness and also to help screen reader users. I've tested my fixes using the VoiceOver screen reader on a Mac and also with the axe Chrome extension.

The fixes include:
- use a `label` element to identify the autofocus input rather than plain text
- wrap all page content in a `main` element
- add an `aria-hidden="true"` attribute to the pointing finger icon so screen readers ignore it
- add contextual labels on the "activate trap" and "deactivate trap" buttons
- add spaces between a few words in the "containerElements" and "containerElements (no child)" demos
- use the `&&` operator to conditionally render the focus trap rather than an unnecessary ternary
- update the Cypress tests to still pass with the new changes

Question: These changes affect the demo page. I assume that we first want to merge this to master and then one of the maintainers will merge the master branch into the gh-pages branch to publish a new demo page? Let me know if I'm off-base in setting my PR here to merge to the master branch.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- ~Issue being fixed is referenced.~
- Source changes maintain:
  - [x] Stated browser compatibility.
  - [x] Stated React compatibility.
- ~Unit test coverage added/updated.~
- [x] E2E test coverage added/updated.
- ~Prop-types added/updated.~
- ~Typings added/updated.~
- ~README updated (API changes, instructions, etc.).~
- ~Changes to dependencies explained.~
- ~Changeset added (run `yarn changeset` locally to add one, and follow the prompts).~
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
