### PR TITLE
docs: adds a code coverage badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# focus-trap-react [![CI](https://github.com/focus-trap/focus-trap-react/workflows/CI/badge.svg?branch=master&event=push)](https://github.com/focus-trap/focus-trap-react/actions?query=workflow:CI+branch:master) [![license](https://badgen.now.sh/badge/license/MIT)](./LICENSE)
+# focus-trap-react [![CI](https://github.com/focus-trap/focus-trap-react/workflows/CI/badge.svg?branch=master&event=push)](https://github.com/focus-trap/focus-trap-react/actions?query=workflow:CI+branch:master) [![Codecov](https://img.shields.io/codecov/c/github/focus-trap/focus-trap-react)](https://codecov.io/gh/focus-trap/focus-trap-react) [![license](https://badgen.now.sh/badge/license/MIT)](./LICENSE)
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-17-orange.svg?style=flat-square)](#contributors)


### PR DESCRIPTION
I've added a code coverage badge from Codecov to the README. This repo has 97% code coverage through the Jest unit tests, so we may as well flaunt it. Behold!

<img width="516" alt="Screen Shot 2020-12-26 at 10 03 10 PM" src="https://user-images.githubusercontent.com/13806458/103164261-39938d00-47c6-11eb-909a-768222168611.png">

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- ~Issue being fixed is referenced.~
- Source changes maintain:
  - ~Stated browser compatibility.~
  - ~Stated React compatibility.~
- ~Unit test coverage added/updated.~
- ~E2E test coverage added/updated.~
- ~Prop-types added/updated.~
- ~Typings added/updated.~
- [x] README updated (API changes, instructions, etc.).
- ~Changes to dependencies explained.~
- ~Changeset added (run `yarn changeset` locally to add one, and follow the prompts).~
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
