### PR TITLE
Remove clickOutsideDeactivates propType warning

### DIFF
--- a/.changeset/eighty-wolves-switch.md
+++ b/.changeset/eighty-wolves-switch.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': patch
+---
+
+Update PropTypes for clickOutsideDeactivates to match latest focus-trap

--- a/.changeset/eighty-wolves-switch.md
+++ b/.changeset/eighty-wolves-switch.md
@@ -2,4 +2,4 @@
 'focus-trap-react': patch
 ---
 
-Update PropTypes for clickOutsideDeactivates to match latest focus-trap
+Update PropTypes for clickOutsideDeactivates to match latest focus-trap.

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -189,7 +189,10 @@ FocusTrap.propTypes = {
       PropTypes.func,
     ]),
     escapeDeactivates: PropTypes.bool,
-    clickOutsideDeactivates: PropTypes.bool,
+    clickOutsideDeactivates: PropTypes.oneOfType([
+      PropTypes.bool,
+      PropTypes.func,
+    ]),
     returnFocusOnDeactivate: PropTypes.bool,
     setReturnFocus: PropTypes.oneOfType([
       PropTypes.instanceOf(ElementType),


### PR DESCRIPTION
Current implementation displays the following warning when a function is passed as the `clickOutsideDeactivates` prop. This was added in version `6.3.0` of focus-trap in [this commit](https://github.com/focus-trap/focus-trap/commit/a882d62532d0861cad5e76111f449eb3effe1106).

**Warning:**

`Warning: Failed prop type: Invalid prop `focusTrapOptions.clickOutsideDeactivates` of type `function` supplied to `FocusTrap`, expected `boolean`.`

It works as expected, but this is just an update to the propType definitions to prevent the error from displaying.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain:
  - Stated browser compatibility.
  - Stated React compatibility.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Prop-types added/updated.
- Typings added/updated.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
