### PR TITLE
Throw error if child is a Fragment

### DIFF
--- a/.changeset/cool-kiwis-float.md
+++ b/.changeset/cool-kiwis-float.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': patch
+---
+
+Throw an error if a Fragment is given as the child container (currently, it appears to work, but the trap is actually not activated because focus-trap can't find the DOM element for the Fragment "container". (Fixes #268)

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Why? Because this module's core functionality comes from focus-trap, which uses 
 
 ## Usage
 
-You wrap any element that you want to act as a focus trap with the `<FocusTrap>` component. `<FocusTrap>` expects exactly one child element which can be any HTML element or other React component that contains focusable elements.
+You wrap any element that you want to act as a focus trap with the `<FocusTrap>` component. `<FocusTrap>` expects exactly one child element which can be any HTML element or other React component that contains focusable elements. __It cannot be a Fragment__ because `<FocusTrap>` needs to be able to get a reference to the underlying HTML element, and Fragments do not have any representation in the DOM.
 
 For example:
 
@@ -69,11 +69,9 @@ Here's one more simple example:
 ```js
 const React = require('react');
 const ReactDOM = require('react-dom');
-const FocusTrap = require('../../dist/focus-trap-react');
+const FocusTrap = require('focus-trap-react');
 
-const container = document.getElementById('demo-one');
-
-class DemoOne extends React.Component {
+class Demo extends React.Component {
   constructor(props) {
     super(props);
 
@@ -85,13 +83,13 @@ class DemoOne extends React.Component {
     this.unmountTrap = this.unmountTrap.bind(this);
   }
 
-  mountTrap() {
+  mountTrap = () => {
     this.setState({ activeTrap: true });
-  }
+  };
 
-  unmountTrap() {
+  unmountTrap = () => {
     this.setState({ activeTrap: false });
-  }
+  };
 
   render() {
     const trap = this.state.activeTrap
@@ -134,7 +132,7 @@ class DemoOne extends React.Component {
   }
 }
 
-ReactDOM.render(<DemoOne />, container);
+ReactDOM.render(<Demo />, document.getElementById('root'));
 ```
 
 ### Props

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -142,6 +142,12 @@ class FocusTrap extends React.Component {
       : undefined;
 
     if (child) {
+      if (child.type && child.type === React.Fragment) {
+        throw new Error(
+          'A focus-trap cannot use a Fragment as its child container. Try replacing it with a <div> element.'
+        );
+      }
+
       const composedRefCallback = (element) => {
         const { containerElements } = this.props;
 

--- a/test/focus-trap-react.test.js
+++ b/test/focus-trap-react.test.js
@@ -98,6 +98,20 @@ describe('FocusTrap', () => {
         'Your focus-trap must have at least one container with at least one tabbable node in it at all times'
       );
     });
+
+    it('throws an error if a fragment is given as the child element', () => {
+      expect(() =>
+        render(
+          <FocusTrap>
+            <>
+              <button>Click me</button>
+            </>
+          </FocusTrap>
+        )
+      ).toThrowError(
+        'A focus-trap cannot use a Fragment as its child container. Try replacing it with a <div> element.'
+      );
+    });
   });
 
   describe('correct children prop usage', () => {


### PR DESCRIPTION
Fixes #268

Right now, this silently "fails" and appears to work, but it's actually not
working because the trap isn't activated, because it couldn't find a DOM
element for the Fragment.

This change throws an error if a child is given and it's a Fragment.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain:
  - Stated browser compatibility.
  - Stated React compatibility.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Prop-types added/updated.
- Typings added/updated.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
