### PR TITLE
Adding new focus trap options support

### DIFF
--- a/.changeset/quick-months-notice.md
+++ b/.changeset/quick-months-notice.md
@@ -1,0 +1,5 @@
+---
+"focus-trap-react": minor
+---
+
+Adding support for new focus-trap options from focus-trap v6.5.0: `checkCanFocusTrap()`, `onPostActivate()`, `checkCanReturnFocus()`, and `onPostDeactivate()`.

--- a/cypress/integration/focus-trap-demo.spec.js
+++ b/cypress/integration/focus-trap-demo.spec.js
@@ -13,63 +13,71 @@ describe('<FocusTrap> component', () => {
     cy.get(focusedElAlias).should('be.focused');
   }
 
-  ['defaults', 'animated-dialog', 'animated-trigger'].forEach((demoId) => {
-    describe(`demo: ${demoId}`, () => {
-      it('By default focus first element in its tab order and trap focus within its children', () => {
-        cy.get(`#demo-${demoId}`).as('testRoot');
+  ['defaults', 'animated-dialog', 'animated-trigger', 'setReturnFocus'].forEach(
+    (demoId) => {
+      describe(`demo: ${demoId}`, () => {
+        it('By default focus first element in its tab order and trap focus within its children', () => {
+          cy.get(`#demo-${demoId}`).as('testRoot');
 
-        // activate trap
-        cy.get('@testRoot')
-          .findByRole('button', { name: /^activate trap/ })
-          .as('lastlyFocusedElementBeforeTrapIsActivated')
-          .click();
+          // activate trap
+          cy.get('@testRoot')
+            .findByRole('button', { name: /^activate trap/ })
+            .as('lastlyFocusedElementBeforeTrapIsActivated')
+            .click();
 
-        // 1st element should be focused
-        cy.get('@testRoot')
-          .findByRole('link', { name: 'with' })
-          .as('firstElementInTrap')
-          .should('be.focused');
+          // 1st element should be focused
+          cy.get('@testRoot')
+            .findByRole('link', { name: 'with' })
+            .as('firstElementInTrap')
+            .should('be.focused');
 
-        // crucial focus-trap feature: mouse click is trapped
-        verifyCrucialFocusTrapOnClicking('@firstElementInTrap');
+          // crucial focus-trap feature: mouse click is trapped
+          verifyCrucialFocusTrapOnClicking('@firstElementInTrap');
 
-        // trap is active(keep focus in trap by tabbing through the focus trap's tabbable elements)
-        cy.get('@firstElementInTrap')
-          .tab()
-          .should('have.text', 'some')
-          .should('be.focused')
-          .tab()
-          .should('have.text', 'focusable')
-          .should('be.focused')
-          .tab()
-          .as('lastElementInTrap')
-          .should('have.text', 'deactivate trap')
-          .should('be.focused')
-          .tab();
+          // trap is active(keep focus in trap by tabbing through the focus trap's tabbable elements)
+          cy.get('@firstElementInTrap')
+            .tab()
+            .should('have.text', 'some')
+            .should('be.focused')
+            .tab()
+            .should('have.text', 'focusable')
+            .should('be.focused')
+            .tab()
+            .as('lastElementInTrap')
+            .should('have.text', 'deactivate trap')
+            .should('be.focused')
+            .tab();
 
-        // trap is active(keep focus in trap by shift-tabbing through the focus trap's tabbable elements)
-        cy.get('@firstElementInTrap').should('be.focused').tab({ shift: true });
-        cy.get('@lastElementInTrap').should('be.focused');
+          // trap is active(keep focus in trap by shift-tabbing through the focus trap's tabbable elements)
+          cy.get('@firstElementInTrap')
+            .should('be.focused')
+            .tab({ shift: true });
+          cy.get('@lastElementInTrap').should('be.focused');
 
-        // trap can be deactivated and return focus to lastly focused element before trap is activated
-        cy.get('@testRoot')
-          .findByRole('button', { name: /^deactivate trap/ })
-          .click();
-        cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should(
-          'have.focus'
-        );
+          // trap can be deactivated and return focus to lastly focused element before trap is activated
+          cy.get('@testRoot')
+            .findByRole('button', { name: /^deactivate trap/ })
+            .click();
 
-        // focus can be transitioned freely when trap is unmounted
-        let previousFocusedEl;
-        cy.get('@lastlyFocusedElementBeforeTrapIsActivated')
-          .then(([lastlyFocusedEl]) => (previousFocusedEl = lastlyFocusedEl))
-          .tab();
-        cy.focused().should(([nextFocusedEl]) =>
-          expect(nextFocusedEl).not.equal(previousFocusedEl)
-        );
+          const returnFocusTarget =
+            demoId === 'setReturnFocus'
+              ? '#AlternateReturnFocusElement'
+              : '@lastlyFocusedElementBeforeTrapIsActivated';
+
+          cy.get(returnFocusTarget).should('have.focus');
+
+          // focus can be transitioned freely when trap is unmounted
+          let previousFocusedEl;
+          cy.get('@lastlyFocusedElementBeforeTrapIsActivated')
+            .then(([lastlyFocusedEl]) => (previousFocusedEl = lastlyFocusedEl))
+            .tab();
+          cy.focused().should(([nextFocusedEl]) =>
+            expect(nextFocusedEl).not.equal(previousFocusedEl)
+          );
+        });
       });
-    });
-  });
+    }
+  );
 
   describe('demo: ffne', () => {
     it('On trap mounts and activates, focus on manually specified input element', () => {

--- a/cypress/integration/focus-trap-demo.spec.js
+++ b/cypress/integration/focus-trap-demo.spec.js
@@ -1,22 +1,3 @@
-/**
- * Verify focus trap is **NOT** trapping focus by tab
- * @param cyWrapper Cypress object of outside focused element yielded from `cy.get/contains/findByRole...etc`
- */
-function verifyFocusIsNotTrapped(cyWrapper) {
-  const outsideFocusedElAlias = 'outsideFocusedEl';
-  cyWrapper.as(outsideFocusedElAlias).should('be.focused');
-  // focus can be transitioned freely when trap is unmounted
-  let previousFocusedEl;
-  cy.get(`@${outsideFocusedElAlias}`)
-    .then(([lastlyFocusedEl]) => {
-      return (previousFocusedEl = lastlyFocusedEl);
-    })
-    .tab();
-  cy.focused().should(([nextFocusedEl]) =>
-    expect(nextFocusedEl).not.equal(previousFocusedEl)
-  );
-}
-
 describe('<FocusTrap> component', () => {
   beforeEach(() => cy.visit('index.html'));
 
@@ -102,13 +83,8 @@ describe('<FocusTrap> component', () => {
         .as('firstElementInTrap')
         .should('be.focused');
 
-      // trap is active(keep focus in trap by blocking clicks on outside focusable element)
-      cy.get('#return-to-repo').click();
-      cy.get('@firstElementInTrap').should('be.focused');
-
-      // trap is active(keep focus in trap by blocking clicks on outside un-focusable element)
-      cy.get('#animated-dialog-heading').click();
-      cy.get('@firstElementInTrap').should('be.focused');
+      // crucial focus-trap feature: mouse click is trapped
+      verifyCrucialFocusTrapOnClicking('@firstElementInTrap');
 
       // trap is active(keep focus in trap by tabbing through the focus trap's tabbable elements)
       cy.get('@firstElementInTrap')
@@ -120,7 +96,7 @@ describe('<FocusTrap> component', () => {
         .should('be.focused')
         .tab()
         .as('lastElementInTrap')
-        .should('contain', 'deactivate trap')
+        .should('have.text', 'deactivate trap')
         .should('be.focused')
         .tab();
 
@@ -128,38 +104,19 @@ describe('<FocusTrap> component', () => {
       cy.get('@firstElementInTrap').should('be.focused').tab({ shift: true });
       cy.get('@lastElementInTrap').should('be.focused');
 
-      // focus can be transitioned freely when trap is deactivated
+      // trap can be deactivated and return focus to lastly focused element before trap is activated
       cy.get('@testRoot')
         .findByRole('button', { name: /^deactivate trap/ })
         .click();
-      verifyFocusIsNotTrapped(
-        cy.get('@lastlyFocusedElementBeforeTrapIsActivated')
-      );
-    });
+      cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should('have.focus');
 
-    it('allows deactivation by pressing ESC', () => {
-      cy.get('#demo-animated-dialog').as('testRoot');
-
-      // activate trap
-      cy.get('@testRoot')
-        .findByRole('button', { name: /^activate trap/ })
-        .as('lastlyFocusedElementBeforeTrapIsActivated')
-        .click();
-
-      // 1st element should be focused
-      cy.get('@testRoot')
-        .findByRole('link', { name: 'with' })
-        .as('firstElementInTrap')
-        .should('be.focused');
-
-      // trap is active(keep focus in trap by blocking clicks on outside focusable element)
-      cy.get('#return-to-repo').click();
-      cy.get('@firstElementInTrap').should('be.focused');
-
-      // focus can be transitioned freely when trap is deactivated
-      cy.get('@firstElementInTrap').type('{esc}');
-      verifyFocusIsNotTrapped(
-        cy.get('@lastlyFocusedElementBeforeTrapIsActivated')
+      // focus can be transitioned freely when trap is unmounted
+      let previousFocusedEl;
+      cy.get('@lastlyFocusedElementBeforeTrapIsActivated')
+        .then(([lastlyFocusedEl]) => (previousFocusedEl = lastlyFocusedEl))
+        .tab();
+      cy.focused().should(([nextFocusedEl]) =>
+        expect(nextFocusedEl).not.equal(previousFocusedEl)
       );
     });
   });
@@ -180,13 +137,8 @@ describe('<FocusTrap> component', () => {
         .as('firstElementInTrap')
         .should('be.focused');
 
-      // trap is active(keep focus in trap by blocking clicks on outside focusable element)
-      cy.get('#return-to-repo').click();
-      cy.get('@firstElementInTrap').should('be.focused');
-
-      // trap is active(keep focus in trap by blocking clicks on outside un-focusable element)
-      cy.get('#animated-trigger-heading').click();
-      cy.get('@firstElementInTrap').should('be.focused');
+      // crucial focus-trap feature: mouse click is trapped
+      verifyCrucialFocusTrapOnClicking('@firstElementInTrap');
 
       // trap is active(keep focus in trap by tabbing through the focus trap's tabbable elements)
       cy.get('@firstElementInTrap')
@@ -198,7 +150,7 @@ describe('<FocusTrap> component', () => {
         .should('be.focused')
         .tab()
         .as('lastElementInTrap')
-        .should('contain', 'deactivate trap')
+        .should('have.text', 'deactivate trap')
         .should('be.focused')
         .tab();
 
@@ -206,38 +158,19 @@ describe('<FocusTrap> component', () => {
       cy.get('@firstElementInTrap').should('be.focused').tab({ shift: true });
       cy.get('@lastElementInTrap').should('be.focused');
 
-      // focus can be transitioned freely when trap is deactivated
+      // trap can be deactivated and return focus to lastly focused element before trap is activated
       cy.get('@testRoot')
         .findByRole('button', { name: /^deactivate trap/ })
         .click();
-      verifyFocusIsNotTrapped(
-        cy.get('@lastlyFocusedElementBeforeTrapIsActivated')
-      );
-    });
+      cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should('have.focus');
 
-    it('allows deactivation by pressing ESC', () => {
-      cy.get('#demo-animated-trigger').as('testRoot');
-
-      // activate trap
-      cy.get('@testRoot')
-        .findByRole('button', { name: /^activate trap/ })
-        .as('lastlyFocusedElementBeforeTrapIsActivated')
-        .click();
-
-      // 1st element should be focused
-      cy.get('@testRoot')
-        .findByRole('link', { name: 'with' })
-        .as('firstElementInTrap')
-        .should('be.focused');
-
-      // trap is active(keep focus in trap by blocking clicks on outside focusable element)
-      cy.get('#return-to-repo').click();
-      cy.get('@firstElementInTrap').should('be.focused');
-
-      // focus can be transitioned freely when trap is deactivated
-      cy.get('@firstElementInTrap').type('{esc}');
-      verifyFocusIsNotTrapped(
-        cy.get('@lastlyFocusedElementBeforeTrapIsActivated')
+      // focus can be transitioned freely when trap is unmounted
+      let previousFocusedEl;
+      cy.get('@lastlyFocusedElementBeforeTrapIsActivated')
+        .then(([lastlyFocusedEl]) => (previousFocusedEl = lastlyFocusedEl))
+        .tab();
+      cy.focused().should(([nextFocusedEl]) =>
+        expect(nextFocusedEl).not.equal(previousFocusedEl)
       );
     });
   });

--- a/cypress/integration/focus-trap-demo.spec.js
+++ b/cypress/integration/focus-trap-demo.spec.js
@@ -13,165 +13,61 @@ describe('<FocusTrap> component', () => {
     cy.get(focusedElAlias).should('be.focused');
   }
 
-  describe('demo: defaults', () => {
-    it('By default focus first element in its tab order and trap focus within its children', () => {
-      cy.get('#demo-defaults').as('testRoot');
+  ['defaults', 'animated-dialog', 'animated-trigger'].forEach((demoId) => {
+    describe(`demo: ${demoId}`, () => {
+      it('By default focus first element in its tab order and trap focus within its children', () => {
+        cy.get(`#demo-${demoId}`).as('testRoot');
 
-      // activate trap
-      cy.get('@testRoot')
-        .findByRole('button', { name: /^activate trap/ })
-        .as('lastlyFocusedElementBeforeTrapIsActivated')
-        .click();
+        // activate trap
+        cy.get('@testRoot')
+          .findByRole('button', { name: /^activate trap/ })
+          .as('lastlyFocusedElementBeforeTrapIsActivated')
+          .click();
 
-      // 1st element should be focused
-      cy.get('@testRoot')
-        .findByRole('link', { name: 'with' })
-        .as('firstElementInTrap')
-        .should('be.focused');
+        // 1st element should be focused
+        cy.get('@testRoot')
+          .findByRole('link', { name: 'with' })
+          .as('firstElementInTrap')
+          .should('be.focused');
 
-      // crucial focus-trap feature: mouse click is trapped
-      verifyCrucialFocusTrapOnClicking('@firstElementInTrap');
+        // crucial focus-trap feature: mouse click is trapped
+        verifyCrucialFocusTrapOnClicking('@firstElementInTrap');
 
-      // trap is active(keep focus in trap by tabbing through the focus trap's tabbable elements)
-      cy.get('@firstElementInTrap')
-        .tab()
-        .should('have.text', 'some')
-        .should('be.focused')
-        .tab()
-        .should('have.text', 'focusable')
-        .should('be.focused')
-        .tab()
-        .as('lastElementInTrap')
-        .should('have.text', 'deactivate trap')
-        .should('be.focused')
-        .tab();
+        // trap is active(keep focus in trap by tabbing through the focus trap's tabbable elements)
+        cy.get('@firstElementInTrap')
+          .tab()
+          .should('have.text', 'some')
+          .should('be.focused')
+          .tab()
+          .should('have.text', 'focusable')
+          .should('be.focused')
+          .tab()
+          .as('lastElementInTrap')
+          .should('have.text', 'deactivate trap')
+          .should('be.focused')
+          .tab();
 
-      // trap is active(keep focus in trap by shift-tabbing through the focus trap's tabbable elements)
-      cy.get('@firstElementInTrap').should('be.focused').tab({ shift: true });
-      cy.get('@lastElementInTrap').should('be.focused');
+        // trap is active(keep focus in trap by shift-tabbing through the focus trap's tabbable elements)
+        cy.get('@firstElementInTrap').should('be.focused').tab({ shift: true });
+        cy.get('@lastElementInTrap').should('be.focused');
 
-      // trap can be deactivated and return focus to lastly focused element before trap is activated
-      cy.get('@testRoot')
-        .findByRole('button', { name: /^deactivate trap/ })
-        .click();
-      cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should('have.focus');
+        // trap can be deactivated and return focus to lastly focused element before trap is activated
+        cy.get('@testRoot')
+          .findByRole('button', { name: /^deactivate trap/ })
+          .click();
+        cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should(
+          'have.focus'
+        );
 
-      // focus can be transitioned freely when trap is unmounted
-      let previousFocusedEl;
-      cy.get('@lastlyFocusedElementBeforeTrapIsActivated')
-        .then(([lastlyFocusedEl]) => (previousFocusedEl = lastlyFocusedEl))
-        .tab();
-      cy.focused().should(([nextFocusedEl]) =>
-        expect(nextFocusedEl).not.equal(previousFocusedEl)
-      );
-    });
-  });
-
-  describe('demo: animated-dialog', () => {
-    it('traps focus tab sequence and allows deactivation by clicking deactivate button', () => {
-      cy.get('#demo-animated-dialog').as('testRoot');
-
-      // activate trap
-      cy.get('@testRoot')
-        .findByRole('button', { name: /^activate trap/ })
-        .as('lastlyFocusedElementBeforeTrapIsActivated')
-        .click();
-
-      // 1st element should be focused
-      cy.get('@testRoot')
-        .findByRole('link', { name: 'with' })
-        .as('firstElementInTrap')
-        .should('be.focused');
-
-      // crucial focus-trap feature: mouse click is trapped
-      verifyCrucialFocusTrapOnClicking('@firstElementInTrap');
-
-      // trap is active(keep focus in trap by tabbing through the focus trap's tabbable elements)
-      cy.get('@firstElementInTrap')
-        .tab()
-        .should('have.text', 'some')
-        .should('be.focused')
-        .tab()
-        .should('have.text', 'focusable')
-        .should('be.focused')
-        .tab()
-        .as('lastElementInTrap')
-        .should('have.text', 'deactivate trap')
-        .should('be.focused')
-        .tab();
-
-      // trap is active(keep focus in trap by shift-tabbing through the focus trap's tabbable elements)
-      cy.get('@firstElementInTrap').should('be.focused').tab({ shift: true });
-      cy.get('@lastElementInTrap').should('be.focused');
-
-      // trap can be deactivated and return focus to lastly focused element before trap is activated
-      cy.get('@testRoot')
-        .findByRole('button', { name: /^deactivate trap/ })
-        .click();
-      cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should('have.focus');
-
-      // focus can be transitioned freely when trap is unmounted
-      let previousFocusedEl;
-      cy.get('@lastlyFocusedElementBeforeTrapIsActivated')
-        .then(([lastlyFocusedEl]) => (previousFocusedEl = lastlyFocusedEl))
-        .tab();
-      cy.focused().should(([nextFocusedEl]) =>
-        expect(nextFocusedEl).not.equal(previousFocusedEl)
-      );
-    });
-  });
-
-  describe('demo: animated-trigger', () => {
-    it('traps focus tab sequence and allows deactivation by clicking deactivate button', () => {
-      cy.get('#demo-animated-trigger').as('testRoot');
-
-      // activate trap
-      cy.get('@testRoot')
-        .findByRole('button', { name: /^activate trap/ })
-        .as('lastlyFocusedElementBeforeTrapIsActivated')
-        .click();
-
-      // 1st element should be focused
-      cy.get('@testRoot')
-        .findByRole('link', { name: 'with' })
-        .as('firstElementInTrap')
-        .should('be.focused');
-
-      // crucial focus-trap feature: mouse click is trapped
-      verifyCrucialFocusTrapOnClicking('@firstElementInTrap');
-
-      // trap is active(keep focus in trap by tabbing through the focus trap's tabbable elements)
-      cy.get('@firstElementInTrap')
-        .tab()
-        .should('have.text', 'some')
-        .should('be.focused')
-        .tab()
-        .should('have.text', 'focusable')
-        .should('be.focused')
-        .tab()
-        .as('lastElementInTrap')
-        .should('have.text', 'deactivate trap')
-        .should('be.focused')
-        .tab();
-
-      // trap is active(keep focus in trap by shift-tabbing through the focus trap's tabbable elements)
-      cy.get('@firstElementInTrap').should('be.focused').tab({ shift: true });
-      cy.get('@lastElementInTrap').should('be.focused');
-
-      // trap can be deactivated and return focus to lastly focused element before trap is activated
-      cy.get('@testRoot')
-        .findByRole('button', { name: /^deactivate trap/ })
-        .click();
-      cy.get('@lastlyFocusedElementBeforeTrapIsActivated').should('have.focus');
-
-      // focus can be transitioned freely when trap is unmounted
-      let previousFocusedEl;
-      cy.get('@lastlyFocusedElementBeforeTrapIsActivated')
-        .then(([lastlyFocusedEl]) => (previousFocusedEl = lastlyFocusedEl))
-        .tab();
-      cy.focused().should(([nextFocusedEl]) =>
-        expect(nextFocusedEl).not.equal(previousFocusedEl)
-      );
+        // focus can be transitioned freely when trap is unmounted
+        let previousFocusedEl;
+        cy.get('@lastlyFocusedElementBeforeTrapIsActivated')
+          .then(([lastlyFocusedEl]) => (previousFocusedEl = lastlyFocusedEl))
+          .tab();
+        cy.focused().should(([nextFocusedEl]) =>
+          expect(nextFocusedEl).not.equal(previousFocusedEl)
+        );
+      });
     });
   });
 

--- a/cypress/integration/focus-trap-demo.spec.js
+++ b/cypress/integration/focus-trap-demo.spec.js
@@ -1,3 +1,22 @@
+/**
+ * Verify focus trap is **NOT** trapping focus by tab
+ * @param cyWrapper Cypress object of outside focused element yielded from `cy.get/contains/findByRole...etc`
+ */
+function verifyFocusIsNotTrapped(cyWrapper) {
+  const outsideFocusedElAlias = 'outsideFocusedEl';
+  cyWrapper.as(outsideFocusedElAlias).should('be.focused');
+  // focus can be transitioned freely when trap is unmounted
+  let previousFocusedEl;
+  cy.get(`@${outsideFocusedElAlias}`)
+    .then(([lastlyFocusedEl]) => {
+      return (previousFocusedEl = lastlyFocusedEl);
+    })
+    .tab();
+  cy.focused().should(([nextFocusedEl]) =>
+    expect(nextFocusedEl).not.equal(previousFocusedEl)
+  );
+}
+
 describe('<FocusTrap> component', () => {
   beforeEach(() => cy.visit('index.html'));
 
@@ -63,6 +82,162 @@ describe('<FocusTrap> component', () => {
         .tab();
       cy.focused().should(([nextFocusedEl]) =>
         expect(nextFocusedEl).not.equal(previousFocusedEl)
+      );
+    });
+  });
+
+  describe('demo: animated-dialog', () => {
+    it('traps focus tab sequence and allows deactivation by clicking deactivate button', () => {
+      cy.get('#demo-animated-dialog').as('testRoot');
+
+      // activate trap
+      cy.get('@testRoot')
+        .findByRole('button', { name: /^activate trap/ })
+        .as('lastlyFocusedElementBeforeTrapIsActivated')
+        .click();
+
+      // 1st element should be focused
+      cy.get('@testRoot')
+        .findByRole('link', { name: 'with' })
+        .as('firstElementInTrap')
+        .should('be.focused');
+
+      // trap is active(keep focus in trap by blocking clicks on outside focusable element)
+      cy.get('#return-to-repo').click();
+      cy.get('@firstElementInTrap').should('be.focused');
+
+      // trap is active(keep focus in trap by blocking clicks on outside un-focusable element)
+      cy.get('#animated-dialog-heading').click();
+      cy.get('@firstElementInTrap').should('be.focused');
+
+      // trap is active(keep focus in trap by tabbing through the focus trap's tabbable elements)
+      cy.get('@firstElementInTrap')
+        .tab()
+        .should('have.text', 'some')
+        .should('be.focused')
+        .tab()
+        .should('have.text', 'focusable')
+        .should('be.focused')
+        .tab()
+        .as('lastElementInTrap')
+        .should('contain', 'deactivate trap')
+        .should('be.focused')
+        .tab();
+
+      // trap is active(keep focus in trap by shift-tabbing through the focus trap's tabbable elements)
+      cy.get('@firstElementInTrap').should('be.focused').tab({ shift: true });
+      cy.get('@lastElementInTrap').should('be.focused');
+
+      // focus can be transitioned freely when trap is deactivated
+      cy.get('@testRoot')
+        .findByRole('button', { name: /^deactivate trap/ })
+        .click();
+      verifyFocusIsNotTrapped(
+        cy.get('@lastlyFocusedElementBeforeTrapIsActivated')
+      );
+    });
+
+    it('allows deactivation by pressing ESC', () => {
+      cy.get('#demo-animated-dialog').as('testRoot');
+
+      // activate trap
+      cy.get('@testRoot')
+        .findByRole('button', { name: /^activate trap/ })
+        .as('lastlyFocusedElementBeforeTrapIsActivated')
+        .click();
+
+      // 1st element should be focused
+      cy.get('@testRoot')
+        .findByRole('link', { name: 'with' })
+        .as('firstElementInTrap')
+        .should('be.focused');
+
+      // trap is active(keep focus in trap by blocking clicks on outside focusable element)
+      cy.get('#return-to-repo').click();
+      cy.get('@firstElementInTrap').should('be.focused');
+
+      // focus can be transitioned freely when trap is deactivated
+      cy.get('@firstElementInTrap').type('{esc}');
+      verifyFocusIsNotTrapped(
+        cy.get('@lastlyFocusedElementBeforeTrapIsActivated')
+      );
+    });
+  });
+
+  describe('demo: animated-trigger', () => {
+    it('traps focus tab sequence and allows deactivation by clicking deactivate button', () => {
+      cy.get('#demo-animated-trigger').as('testRoot');
+
+      // activate trap
+      cy.get('@testRoot')
+        .findByRole('button', { name: /^activate trap/ })
+        .as('lastlyFocusedElementBeforeTrapIsActivated')
+        .click();
+
+      // 1st element should be focused
+      cy.get('@testRoot')
+        .findByRole('link', { name: 'with' })
+        .as('firstElementInTrap')
+        .should('be.focused');
+
+      // trap is active(keep focus in trap by blocking clicks on outside focusable element)
+      cy.get('#return-to-repo').click();
+      cy.get('@firstElementInTrap').should('be.focused');
+
+      // trap is active(keep focus in trap by blocking clicks on outside un-focusable element)
+      cy.get('#animated-trigger-heading').click();
+      cy.get('@firstElementInTrap').should('be.focused');
+
+      // trap is active(keep focus in trap by tabbing through the focus trap's tabbable elements)
+      cy.get('@firstElementInTrap')
+        .tab()
+        .should('have.text', 'some')
+        .should('be.focused')
+        .tab()
+        .should('have.text', 'focusable')
+        .should('be.focused')
+        .tab()
+        .as('lastElementInTrap')
+        .should('contain', 'deactivate trap')
+        .should('be.focused')
+        .tab();
+
+      // trap is active(keep focus in trap by shift-tabbing through the focus trap's tabbable elements)
+      cy.get('@firstElementInTrap').should('be.focused').tab({ shift: true });
+      cy.get('@lastElementInTrap').should('be.focused');
+
+      // focus can be transitioned freely when trap is deactivated
+      cy.get('@testRoot')
+        .findByRole('button', { name: /^deactivate trap/ })
+        .click();
+      verifyFocusIsNotTrapped(
+        cy.get('@lastlyFocusedElementBeforeTrapIsActivated')
+      );
+    });
+
+    it('allows deactivation by pressing ESC', () => {
+      cy.get('#demo-animated-trigger').as('testRoot');
+
+      // activate trap
+      cy.get('@testRoot')
+        .findByRole('button', { name: /^activate trap/ })
+        .as('lastlyFocusedElementBeforeTrapIsActivated')
+        .click();
+
+      // 1st element should be focused
+      cy.get('@testRoot')
+        .findByRole('link', { name: 'with' })
+        .as('firstElementInTrap')
+        .should('be.focused');
+
+      // trap is active(keep focus in trap by blocking clicks on outside focusable element)
+      cy.get('#return-to-repo').click();
+      cy.get('@firstElementInTrap').should('be.focused');
+
+      // focus can be transitioned freely when trap is deactivated
+      cy.get('@firstElementInTrap').type('{esc}');
+      verifyFocusIsNotTrapped(
+        cy.get('@lastlyFocusedElementBeforeTrapIsActivated')
       );
     });
   });

--- a/demo/index.html
+++ b/demo/index.html
@@ -27,6 +27,28 @@
       </a>
     </p>
 
+    <h2 id="animated-dialog-heading">animated dialog</h2>
+    <p>
+        This focus trap will fade in when activated and fade out when deactivated. It logs a message to the
+        console when the trap has finished activating. Note that the fade animation needs to be written yourself,
+        it is not built into the library.
+    </p>
+    <div id="demo-animated-dialog"></div>
+    <p>
+      <a href="https://github.com/focus-trap/focus-trap-react/blob/master/demo/js/demo-animated-dialog.js" aria-describedby="animated-dialog-heading">View demo source <span aria-hidden="true">&gt;&gt;</span></a>
+    </p>
+
+    <h2 id="animated-trigger-heading">animated trigger</h2>
+    <p>
+      The activation button for this focus trap will fade out when the trap activates and fade in when the trap deactivates.
+      It logs a message to the console when the trigger has received focus again. Note that the fade animation needs to be
+      written yourself, it is not built into the library.
+    </p>
+    <div id="demo-animated-trigger"></div>
+    <p>
+      <a href="https://github.com/focus-trap/focus-trap-react/blob/master/demo/js/animated-trigger.js" aria-describedby="animated-trigger-heading">View demo source <span aria-hidden="true">&gt;&gt;</span></a>
+    </p>
+
     <h2 id="ffne-heading">first focus, no escape</h2>
     <p>
       When this FocusTrap mounts (and activates), focus jumps to a specific, manually specified element.

--- a/demo/index.html
+++ b/demo/index.html
@@ -123,7 +123,7 @@
     </p>
     <h2 id="setReturnFocus-heading">demo setReturnFocus option applied</h2>
     <p>
-      When this focus trap deactivates, it will send focus to the 
+      When this focus trap deactivates, it will send focus to the "Alternate Return Focus Element"
     </p>
     <div id="demo-setReturnFocus"></div>
     <p>

--- a/demo/index.html
+++ b/demo/index.html
@@ -127,7 +127,7 @@
     </p>
     <div id="demo-setReturnFocus"></div>
     <p>
-      <a href="https://github.com/focus-trap/focus-trap-react/blob/master/demo/js/demo-setReturnFocus.js" aria-describedby="setReturnFocus-heading-heading">
+      <a href="https://github.com/focus-trap/focus-trap-react/blob/master/demo/js/demo-setReturnFocus.js" aria-describedby="setReturnFocus-heading">
         View demo source <span aria-hidden="true">&gt;&gt;</span>
       </a>
     </p>

--- a/demo/index.html
+++ b/demo/index.html
@@ -121,6 +121,16 @@
         View demo source <span aria-hidden="true">&gt;&gt;</span>
       </a>
     </p>
+    <h2 id="setReturnFocus-heading">demo setReturnFocus option applied</h2>
+    <p>
+      When this focus trap deactivates, it will send focus to the 
+    </p>
+    <div id="demo-setReturnFocus"></div>
+    <p>
+      <a href="https://github.com/focus-trap/focus-trap-react/blob/master/demo/js/demo-setReturnFocus.js" aria-describedby="setReturnFocus-heading-heading">
+        View demo source <span aria-hidden="true">&gt;&gt;</span>
+      </a>
+    </p>
 
     <p>
       <span aria-hidden="true" style="font-size:2em;vertical-align:middle;">☜</span>

--- a/demo/js/demo-animated-dialog.js
+++ b/demo/js/demo-animated-dialog.js
@@ -1,0 +1,84 @@
+const { useState } = require('react');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const FocusTrap = require('../../dist/focus-trap-react');
+
+const container = document.getElementById('demo-animated-dialog');
+
+const focusTrapOptions = {
+  checkCanFocusTrap: (trapContainers) => {
+    const results = trapContainers.map((trapContainer) => {
+      return new Promise((resolve) => {
+        const interval = setInterval(() => {
+          if (getComputedStyle(trapContainer).visibility !== 'hidden') {
+            resolve();
+            clearInterval(interval);
+          }
+        }, 5);
+      });
+    });
+    // Return a promise that resolves when all the trap containers are able to receive focus
+    return Promise.all(results);
+  },
+  // Called after focus is sent to the focus trap
+  onPostActivate: () => {
+    // eslint-disable-next-line no-console
+    console.log('Focus has been sent to the animated focus trap');
+  },
+};
+
+const DemoAnimatedDialog = () => {
+  const [isTrapActive, setIsTrapActive] = useState(false);
+
+  return (
+    <>
+      <style>{`
+      .animated-dialog {
+        position: absolute;
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity 0.5s, visibility 0.5s;
+      }
+      .animated-dialog.is-active {
+        opacity: 1;
+        visibility: visible;
+      }
+      `}</style>
+      <div>
+        <p>
+          <button
+            onClick={() => setIsTrapActive(true)}
+            aria-label="activate trap for 'fading' demo"
+          >
+            activate trap
+          </button>
+        </p>
+      </div>
+
+      <FocusTrap active={isTrapActive} focusTrapOptions={focusTrapOptions}>
+        <div
+          className={[
+            'trap',
+            'animated-dialog',
+            isTrapActive ? 'is-active' : '',
+          ].join(' ')}
+        >
+          <p>
+            Here is a focus trap <a href="#">with</a> <a href="#">some</a>{' '}
+            <a href="#">focusable</a> parts.
+          </p>
+          <p>
+            <button
+              onClick={() => setIsTrapActive(false)}
+              aria-label="deactivate trap for 'defaults' demo"
+            >
+              deactivate trap
+            </button>
+          </p>
+        </div>
+      </FocusTrap>
+    </>
+  );
+};
+
+ReactDOM.render(<DemoAnimatedDialog />, container);

--- a/demo/js/demo-animated-dialog.js
+++ b/demo/js/demo-animated-dialog.js
@@ -48,7 +48,7 @@ const DemoAnimatedDialog = () => {
         <p>
           <button
             onClick={() => setIsTrapActive(true)}
-            aria-label="activate trap for 'fading' demo"
+            aria-describedby="animated-dialog-heading"
           >
             activate trap
           </button>
@@ -70,7 +70,7 @@ const DemoAnimatedDialog = () => {
           <p>
             <button
               onClick={() => setIsTrapActive(false)}
-              aria-label="deactivate trap for 'defaults' demo"
+              aria-describedby="animated-dialog-heading"
             >
               deactivate trap
             </button>

--- a/demo/js/demo-animated-trigger.js
+++ b/demo/js/demo-animated-trigger.js
@@ -49,7 +49,7 @@ const DemoAnimatedTrigger = () => {
               isTrapActive ? 'is-active' : '',
             ].join(' ')}
             onClick={() => setIsTrapActive(true)}
-            aria-label="activate trap for 'fading' demo"
+            aria-describedby="animated-trigger-heading"
           >
             activate trap
           </button>
@@ -65,7 +65,7 @@ const DemoAnimatedTrigger = () => {
           <p>
             <button
               onClick={() => setIsTrapActive(false)}
-              aria-label="deactivate trap for 'defaults' demo"
+              aria-describedby="animated-trigger-heading"
             >
               deactivate trap
             </button>

--- a/demo/js/demo-animated-trigger.js
+++ b/demo/js/demo-animated-trigger.js
@@ -1,0 +1,79 @@
+const { useState } = require('react');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const FocusTrap = require('../../dist/focus-trap-react');
+
+const container = document.getElementById('demo-animated-trigger');
+
+const focusTrapOptions = {
+  // There is a delay between when the class is removed
+  // and when the trigger is focusable
+  checkCanReturnFocus: (triggerButton) => {
+    return new Promise((resolve) => {
+      const interval = setInterval(() => {
+        if (getComputedStyle(triggerButton).visibility !== 'hidden') {
+          resolve();
+          clearInterval(interval);
+        }
+      }, 5);
+    });
+  },
+  // Called after focus is sent to the trigger button
+  onPostDeactivate: () => {
+    // eslint-disable-next-line no-console
+    console.log(
+      'Focus has been sent to the animated focus trap trigger button'
+    );
+  },
+};
+
+const DemoAnimatedTrigger = () => {
+  const [isTrapActive, setIsTrapActive] = useState(false);
+
+  return (
+    <>
+      <style>{`
+      .animated-trigger {
+        transition: opacity 0.5s, visibility 0.5s;
+      }
+      .animated-trigger.is-active {
+        opacity: 0;
+        visibility: hidden;
+      }
+      `}</style>
+      <div>
+        <p>
+          <button
+            className={[
+              'animated-trigger',
+              isTrapActive ? 'is-active' : '',
+            ].join(' ')}
+            onClick={() => setIsTrapActive(true)}
+            aria-label="activate trap for 'fading' demo"
+          >
+            activate trap
+          </button>
+        </p>
+      </div>
+
+      <FocusTrap active={isTrapActive} focusTrapOptions={focusTrapOptions}>
+        <div className={['trap', isTrapActive ? 'is-active' : ''].join(' ')}>
+          <p>
+            Here is a focus trap <a href="#">with</a> <a href="#">some</a>{' '}
+            <a href="#">focusable</a> parts.
+          </p>
+          <p>
+            <button
+              onClick={() => setIsTrapActive(false)}
+              aria-label="deactivate trap for 'defaults' demo"
+            >
+              deactivate trap
+            </button>
+          </p>
+        </div>
+      </FocusTrap>
+    </>
+  );
+};
+
+ReactDOM.render(<DemoAnimatedTrigger />, container);

--- a/demo/js/demo-setReturnFocus.js
+++ b/demo/js/demo-setReturnFocus.js
@@ -1,0 +1,53 @@
+const { useState } = require('react');
+const React = require('react');
+const ReactDOM = require('react-dom');
+const FocusTrap = require('../../dist/focus-trap-react');
+
+const container = document.getElementById('demo-setReturnFocus');
+
+const focusTrapOptions = {
+  setReturnFocus: '#AlternateReturnFocusElement',
+};
+
+const DemoSetReturnFocusDialog = () => {
+  const [isTrapActive, setIsTrapActive] = useState(false);
+
+  return (
+    <>
+      <div>
+        <p>
+          <button
+            onClick={() => setIsTrapActive(true)}
+            aria-describedby="setReturnFocus-heading"
+          >
+            activate trap
+          </button>
+          <button id="AlternateReturnFocusElement" onClick={() => {}}>
+            Alternate Return Focus Element
+          </button>
+        </p>
+      </div>
+
+      {isTrapActive && (
+        <FocusTrap focusTrapOptions={focusTrapOptions}>
+          <div className="trap">
+            <p>
+              Here is a focus trap <a href="#">with</a> <a href="#">some</a>{' '}
+              <a href="#">focusable</a> parts.
+            </p>
+            <p>
+              <button
+                onClick={() => setIsTrapActive(false)}
+                aria-describedby="setReturnFocus-heading"
+              >
+                deactivate trap
+              </button>
+            </p>
+          </div>
+        </FocusTrap>
+      )}
+    </>
+  );
+};
+
+ReactDOM.render(<DemoSetReturnFocusDialog />, container);

--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -1,4 +1,6 @@
 require('./demo-defaults');
+require('./demo-animated-dialog');
+require('./demo-animated-trigger');
 require('./demo-ffne');
 require('./demo-special-element');
 require('./demo-autofocus');

--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -6,3 +6,4 @@ require('./demo-special-element');
 require('./demo-autofocus');
 require('./demo-containerelements');
 require('./demo-containerelements-childless');
+require('./demo-setReturnFocus');

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -36,6 +36,11 @@ class FocusTrap extends React.Component {
         continue;
       }
 
+      if (optionName === 'onPostDeactivate') {
+        this.onPostDeactivate = focusTrapOptions[optionName];
+        continue;
+      }
+
       this.tailoredFocusTrapOptions[optionName] = focusTrapOptions[optionName];
     }
 
@@ -57,15 +62,14 @@ class FocusTrap extends React.Component {
 
   /** Returns focus to the element that had focus when the trap was activated. */
   returnFocus() {
-    const { checkCanReturnFocus, onPostDeactivate } =
-      this.props.focusTrapOptions;
+    const { checkCanReturnFocus } = this.tailoredFocusTrapOptions;
 
     const sendFocus = () => {
       if (this.previouslyFocusedElement?.focus) {
         this.previouslyFocusedElement.focus();
       }
-      if (onPostDeactivate) {
-        onPostDeactivate();
+      if (this.onPostDeactivate) {
+        this.onPostDeactivate();
       }
     };
 

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -55,14 +55,7 @@ class FocusTrap extends React.Component {
 
   // TODO: Need more test coverage for this function
   getNodeForOption(optionName) {
-    const config = {
-      returnFocusOnDeactivate: true,
-      escapeDeactivates: true,
-      delayInitialFocus: true,
-      ...this.tailoredFocusTrapOptions,
-    };
-
-    const optionValue = config[optionName];
+    const optionValue = this.tailoredFocusTrapOptions[optionName];
     if (!optionValue) {
       return null;
     }

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -118,7 +118,17 @@ class FocusTrap extends React.Component {
         this.focusTrap.updateContainerElements(this.props.containerElements);
       }
 
-      if (prevProps.active && !this.props.active) {
+      const hasActivated = !prevProps.active && this.props.active;
+      const hasDeactivated = prevProps.active && !this.props.active;
+      const hasPaused = !prevProps.paused && this.props.paused;
+      const hasUnpaused = prevProps.paused && !this.props.paused;
+
+      if (hasActivated) {
+        this.updatePreviousElement();
+        this.focusTrap.activate();
+      }
+
+      if (hasDeactivated) {
         // NOTE: we never let the trap return the focus since we do that ourselves
         this.focusTrap.deactivate({ returnFocus: false });
         if (this.returnFocusOnDeactivate) {
@@ -127,15 +137,12 @@ class FocusTrap extends React.Component {
         return; // un/pause does nothing on an inactive trap
       }
 
-      if (!prevProps.active && this.props.active) {
-        this.updatePreviousElement();
-        this.focusTrap.activate();
+      if (hasPaused) {
+        this.focusTrap.pause();
       }
 
-      if (prevProps.paused && !this.props.paused) {
+      if (hasUnpaused) {
         this.focusTrap.unpause();
-      } else if (!prevProps.paused && this.props.paused) {
-        this.focusTrap.pause();
       }
     } else if (prevProps.containerElements !== this.props.containerElements) {
       this.focusTrapElements = this.props.containerElements;

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -57,10 +57,8 @@ class FocusTrap extends React.Component {
 
   /** Returns focus to the element that had focus when the trap was activated. */
   returnFocus() {
-    const {
-      checkCanReturnFocus,
-      onPostDeactivate,
-    } = this.props.focusTrapOptions;
+    const { checkCanReturnFocus, onPostDeactivate } =
+      this.props.focusTrapOptions;
 
     const sendFocus = () => {
       if (this.previouslyFocusedElement?.focus) {

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -63,9 +63,9 @@ class FocusTrap extends React.Component {
     const sendFocus = () => {
       if (this.previouslyFocusedElement?.focus) {
         this.previouslyFocusedElement.focus();
-        if (onPostDeactivate) {
-          onPostDeactivate();
-        }
+      }
+      if (onPostDeactivate) {
+        onPostDeactivate();
       }
     };
 

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -57,8 +57,22 @@ class FocusTrap extends React.Component {
 
   /** Returns focus to the element that had focus when the trap was activated. */
   returnFocus() {
-    if (this.previouslyFocusedElement && this.previouslyFocusedElement.focus) {
-      this.previouslyFocusedElement.focus();
+    const {
+      checkCanReturnFocus,
+      onPostDeactivate,
+    } = this.props.focusTrapOptions;
+
+    const sendFocus = () => {
+      if (this.previouslyFocusedElement?.focus) {
+        this.previouslyFocusedElement.focus();
+        onPostDeactivate();
+      }
+    };
+
+    if (checkCanReturnFocus) {
+      checkCanReturnFocus(this.previouslyFocusedElement).then(sendFocus);
+    } else {
+      sendFocus();
     }
   }
 

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -134,6 +134,9 @@ class FocusTrap extends React.Component {
         if (this.returnFocusOnDeactivate) {
           this.returnFocus();
         }
+        if (this.onPostDeactivate) {
+          this.onPostDeactivate();
+        }
         return; // un/pause does nothing on an inactive trap
       }
 

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -65,7 +65,9 @@ class FocusTrap extends React.Component {
     const sendFocus = () => {
       if (this.previouslyFocusedElement?.focus) {
         this.previouslyFocusedElement.focus();
-        onPostDeactivate();
+        if (onPostDeactivate) {
+          onPostDeactivate();
+        }
       }
     };
 

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -183,7 +183,11 @@ FocusTrap.propTypes = {
   paused: PropTypes.bool,
   focusTrapOptions: PropTypes.shape({
     onActivate: PropTypes.func,
+    onPostActivate: PropTypes.func,
+    checkCanFocusTrap: PropTypes.func,
     onDeactivate: PropTypes.func,
+    onPostDeactivate: PropTypes.func,
+    checkCanReturnFocus: PropTypes.func,
     initialFocus: PropTypes.oneOfType([
       PropTypes.instanceOf(ElementType),
       PropTypes.string,

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -53,6 +53,7 @@ class FocusTrap extends React.Component {
     this.updatePreviousElement();
   }
 
+  // TODO: Need more test coverage for this function
   getNodeForOption(optionName) {
     const config = {
       returnFocusOnDeactivate: true,

--- a/test/focus-trap-react.test.js
+++ b/test/focus-trap-react.test.js
@@ -10,9 +10,7 @@ const FocusTrap = require('../src/focus-trap-react');
 
 const pause = (duration) => {
   return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve();
-    }, duration);
+    setTimeout(resolve, duration);
   });
 };
 

--- a/test/focus-trap-react.test.js
+++ b/test/focus-trap-react.test.js
@@ -325,57 +325,51 @@ describe('FocusTrap', () => {
     });
 
     it('Does not call onPostActivate() until checkCanFocusTrap() has completed', async () => {
-      let hasActivated = false;
-      let hasRunPostActivate = false;
+      const onActivate = jest.fn();
+      const onPostActivate = jest.fn();
+
       render(
         <FocusTrapExample
           focusTrapOptions={{
             checkCanFocusTrap: () => pause(5),
-            onActivate: () => {
-              hasActivated = true;
-            },
-            onPostActivate: () => {
-              hasRunPostActivate = true;
-            },
+            onActivate,
+            onPostActivate,
           }}
         />
       );
 
-      expect(hasActivated).toBe(false);
-      expect(hasRunPostActivate).toBe(false);
+      expect(onActivate).not.toHaveBeenCalled();
+      expect(onPostActivate).not.toHaveBeenCalled();
 
       // Activate the focus trap
       const activateTrapButton = screen.getByText('activate trap');
       activateTrapButton.focus();
       fireEvent.click(activateTrapButton);
 
-      expect(hasActivated).toBe(true);
-      expect(hasRunPostActivate).toBe(false);
+      expect(onActivate).toHaveBeenCalled();
+      expect(onPostActivate).not.toHaveBeenCalled();
 
       await pause(3);
 
-      expect(hasActivated).toBe(true);
-      expect(hasRunPostActivate).toBe(false);
+      expect(onActivate).toHaveBeenCalled();
+      expect(onPostActivate).not.toHaveBeenCalled();
 
       await pause(6);
 
-      expect(hasActivated).toBe(true);
-      expect(hasRunPostActivate).toBe(true);
+      expect(onActivate).toHaveBeenCalled();
+      expect(onPostActivate).toHaveBeenCalled();
     });
 
     it('Does not call onPostDeactivate() until checkCanReturnFocus() has completed', async () => {
-      let hasDeactivated = false;
-      let hasRunPostDeactivate = false;
+      const onDeactivate = jest.fn();
+      const onPostDeactivate = jest.fn();
+
       render(
         <FocusTrapExample
           focusTrapOptions={{
             checkCanReturnFocus: () => pause(5),
-            onDeactivate: () => {
-              hasDeactivated = true;
-            },
-            onPostDeactivate: () => {
-              hasRunPostDeactivate = true;
-            },
+            onDeactivate,
+            onPostDeactivate,
           }}
         />
       );
@@ -390,66 +384,60 @@ describe('FocusTrap', () => {
         expect(screen.getByText('Link 1')).toHaveFocus();
       });
 
-      expect(hasDeactivated).toBe(false);
-      expect(hasRunPostDeactivate).toBe(false);
+      expect(onDeactivate).not.toHaveBeenCalled();
+      expect(onPostDeactivate).not.toHaveBeenCalled();
 
       // Deactivate the focus trap
       fireEvent.click(screen.getByText('deactivate trap'));
 
-      expect(hasDeactivated).toBe(true);
-      expect(hasRunPostDeactivate).toBe(false);
+      expect(onDeactivate).toHaveBeenCalled();
+      expect(onPostDeactivate).not.toHaveBeenCalled();
 
       await pause(3);
 
-      expect(hasDeactivated).toBe(true);
-      expect(hasRunPostDeactivate).toBe(false);
+      expect(onDeactivate).toHaveBeenCalled();
+      expect(onPostDeactivate).not.toHaveBeenCalled();
 
       await pause(6);
 
-      expect(hasDeactivated).toBe(true);
-      expect(hasRunPostDeactivate).toBe(true);
+      expect(onDeactivate).toHaveBeenCalled();
+      expect(onPostDeactivate).toHaveBeenCalled();
     });
 
     it('Will call onPostActivate() even if checkCanFocusTrap() is undefined', async () => {
-      let hasActivated = false;
-      let hasRunPostActivate = false;
+      const onActivate = jest.fn();
+      const onPostActivate = jest.fn();
+
       render(
         <FocusTrapExample
           focusTrapOptions={{
-            onActivate: () => {
-              hasActivated = true;
-            },
-            onPostActivate: () => {
-              hasRunPostActivate = true;
-            },
+            onActivate,
+            onPostActivate,
           }}
         />
       );
 
-      expect(hasActivated).toBe(false);
-      expect(hasRunPostActivate).toBe(false);
+      expect(onActivate).not.toHaveBeenCalled();
+      expect(onPostActivate).not.toHaveBeenCalled();
 
       // Activate the focus trap
       const activateTrapButton = screen.getByText('activate trap');
       activateTrapButton.focus();
       fireEvent.click(activateTrapButton);
 
-      expect(hasActivated).toBe(true);
-      expect(hasRunPostActivate).toBe(true);
+      expect(onActivate).toHaveBeenCalled();
+      expect(onPostActivate).toHaveBeenCalled();
     });
 
     it('Will call onPostDeactivate() even if checkCanReturnFocus() is undefined', async () => {
-      let hasDeactivated = false;
-      let hasRunPostDeactivate = false;
+      const onDeactivate = jest.fn();
+      const onPostDeactivate = jest.fn();
+
       render(
         <FocusTrapExample
           focusTrapOptions={{
-            onDeactivate: () => {
-              hasDeactivated = true;
-            },
-            onPostDeactivate: () => {
-              hasRunPostDeactivate = true;
-            },
+            onDeactivate,
+            onPostDeactivate,
           }}
         />
       );
@@ -464,14 +452,14 @@ describe('FocusTrap', () => {
         expect(screen.getByText('Link 1')).toHaveFocus();
       });
 
-      expect(hasDeactivated).toBe(false);
-      expect(hasRunPostDeactivate).toBe(false);
+      expect(onDeactivate).not.toHaveBeenCalled();
+      expect(onPostDeactivate).not.toHaveBeenCalled();
 
       // Deactivate the focus trap
       fireEvent.click(screen.getByText('deactivate trap'));
 
-      expect(hasDeactivated).toBe(true);
-      expect(hasRunPostDeactivate).toBe(true);
+      expect(onDeactivate).toHaveBeenCalled();
+      expect(onPostDeactivate).toHaveBeenCalled();
     });
   });
 

--- a/test/focus-trap-react.test.js
+++ b/test/focus-trap-react.test.js
@@ -495,6 +495,47 @@ describe('FocusTrap', () => {
       expect(onDeactivate).toHaveBeenCalled();
       expect(onPostDeactivate).toHaveBeenCalled();
     });
+
+    ['string', 'element', 'function'].forEach((elementSelectionMethod) => {
+      it(`Will return focus to setReturnFocus target, setReturnFocus type = ${elementSelectionMethod}`, async () => {
+        render(<div data-testid="AlternateReturnFocusElement" tabIndex={-1} />);
+
+        const selectionMethods = {
+          string: '[data-testid="AlternateReturnFocusElement"]',
+          element: screen.getByTestId('AlternateReturnFocusElement'),
+          function: () => screen.getByTestId('AlternateReturnFocusElement'),
+        };
+
+        render(
+          <FocusTrapExample
+            focusTrapOptions={{
+              setReturnFocus: selectionMethods[elementSelectionMethod],
+            }}
+          />
+        );
+
+        // Activate the focus trap
+        const activateTrapButton = screen.getByText('activate trap');
+        activateTrapButton.focus();
+        fireEvent.click(activateTrapButton);
+
+        // Auto-sets focus inside the focus trap
+        await waitFor(() => {
+          expect(screen.getByText('Link 1')).toHaveFocus();
+        });
+
+        // Deactivate the focus trap
+        const deactivateTrapButton = screen.getByText('deactivate trap');
+        deactivateTrapButton.focus();
+        fireEvent.click(deactivateTrapButton);
+
+        await waitFor(() => {
+          expect(
+            screen.getByTestId('AlternateReturnFocusElement')
+          ).toHaveFocus();
+        });
+      });
+    });
   });
 
   describe('containerElements prop', () => {

--- a/test/focus-trap-react.test.js
+++ b/test/focus-trap-react.test.js
@@ -411,6 +411,70 @@ describe('FocusTrap', () => {
       expect(hasDeactivated).toBe(true);
       expect(hasRunPostDeactivate).toBe(true);
     });
+
+    it('Will call onPostActivate() even if checkCanFocusTrap() is undefined', async () => {
+      let hasActivated = false;
+      let hasRunPostActivate = false;
+      render(
+        <FocusTrapExample
+          focusTrapOptions={{
+            onActivate: () => {
+              hasActivated = true;
+            },
+            onPostActivate: () => {
+              hasRunPostActivate = true;
+            },
+          }}
+        />
+      );
+
+      expect(hasActivated).toBe(false);
+      expect(hasRunPostActivate).toBe(false);
+
+      // Activate the focus trap
+      const activateTrapButton = screen.getByText('activate trap');
+      activateTrapButton.focus();
+      fireEvent.click(activateTrapButton);
+
+      expect(hasActivated).toBe(true);
+      expect(hasRunPostActivate).toBe(true);
+    });
+
+    it('Will call onPostDeactivate() even if checkCanReturnFocus() is undefined', async () => {
+      let hasDeactivated = false;
+      let hasRunPostDeactivate = false;
+      render(
+        <FocusTrapExample
+          focusTrapOptions={{
+            onDeactivate: () => {
+              hasDeactivated = true;
+            },
+            onPostDeactivate: () => {
+              hasRunPostDeactivate = true;
+            },
+          }}
+        />
+      );
+
+      // Activate the focus trap
+      const activateTrapButton = screen.getByText('activate trap');
+      activateTrapButton.focus();
+      fireEvent.click(activateTrapButton);
+
+      // Auto-sets focus inside the focus trap
+      await waitFor(() => {
+        expect(screen.getByText('Link 1')).toHaveFocus();
+      });
+
+      expect(hasDeactivated).toBe(false);
+      expect(hasRunPostDeactivate).toBe(false);
+
+      // Deactivate the focus trap
+      fireEvent.click(screen.getByText('deactivate trap'));
+
+      expect(hasDeactivated).toBe(true);
+      expect(hasRunPostDeactivate).toBe(true);
+    });
   });
 
   describe('containerElements prop', () => {

--- a/test/focus-trap-react.test.js
+++ b/test/focus-trap-react.test.js
@@ -461,6 +461,40 @@ describe('FocusTrap', () => {
       expect(onDeactivate).toHaveBeenCalled();
       expect(onPostDeactivate).toHaveBeenCalled();
     });
+
+    it('Will call onPostDeactivate() even if returnFocusOnDeactivate is false', async () => {
+      const onDeactivate = jest.fn();
+      const onPostDeactivate = jest.fn();
+
+      render(
+        <FocusTrapExample
+          focusTrapOptions={{
+            onDeactivate,
+            onPostDeactivate,
+            returnFocusOnDeactivate: false,
+          }}
+        />
+      );
+
+      // Activate the focus trap
+      const activateTrapButton = screen.getByText('activate trap');
+      activateTrapButton.focus();
+      fireEvent.click(activateTrapButton);
+
+      // Auto-sets focus inside the focus trap
+      await waitFor(() => {
+        expect(screen.getByText('Link 1')).toHaveFocus();
+      });
+
+      expect(onDeactivate).not.toHaveBeenCalled();
+      expect(onPostDeactivate).not.toHaveBeenCalled();
+
+      // Deactivate the focus trap
+      fireEvent.click(screen.getByText('deactivate trap'));
+
+      expect(onDeactivate).toHaveBeenCalled();
+      expect(onPostDeactivate).toHaveBeenCalled();
+    });
   });
 
   describe('containerElements prop', () => {

--- a/test/focus-trap-react.test.js
+++ b/test/focus-trap-react.test.js
@@ -327,11 +327,15 @@ describe('FocusTrap', () => {
     });
 
     it('Does not call onPostActivate() until checkCanFocusTrap() has completed', async () => {
+      let hasActivated = false;
       let hasRunPostActivate = false;
       render(
         <FocusTrapExample
           focusTrapOptions={{
             checkCanFocusTrap: () => pause(500),
+            onActivate: () => {
+              hasActivated = true;
+            },
             onPostActivate: () => {
               hasRunPostActivate = true;
             },
@@ -339,28 +343,38 @@ describe('FocusTrap', () => {
         />
       );
 
+      expect(hasActivated).toBe(false);
+      expect(hasRunPostActivate).toBe(false);
+
       // Activate the focus trap
       const activateTrapButton = screen.getByText('activate trap');
       activateTrapButton.focus();
       fireEvent.click(activateTrapButton);
 
+      expect(hasActivated).toBe(true);
       expect(hasRunPostActivate).toBe(false);
 
       await pause(5);
 
+      expect(hasActivated).toBe(true);
       expect(hasRunPostActivate).toBe(false);
 
       await pause(550);
 
+      expect(hasActivated).toBe(true);
       expect(hasRunPostActivate).toBe(true);
     });
 
     it('Does not call onPostDeactivate() until checkCanReturnFocus() has completed', async () => {
+      let hasDeactivated = false;
       let hasRunPostDeactivate = false;
       render(
         <FocusTrapExample
           focusTrapOptions={{
             checkCanReturnFocus: () => pause(500),
+            onDeactivate: () => {
+              hasDeactivated = true;
+            },
             onPostDeactivate: () => {
               hasRunPostDeactivate = true;
             },
@@ -378,17 +392,23 @@ describe('FocusTrap', () => {
         expect(screen.getByText('Link 1')).toHaveFocus();
       });
 
+      expect(hasDeactivated).toBe(false);
+      expect(hasRunPostDeactivate).toBe(false);
+
       // Deactivate the focus trap
       fireEvent.click(screen.getByText('deactivate trap'));
 
+      expect(hasDeactivated).toBe(true);
       expect(hasRunPostDeactivate).toBe(false);
 
       await pause(5);
 
+      expect(hasDeactivated).toBe(true);
       expect(hasRunPostDeactivate).toBe(false);
 
       await pause(550);
 
+      expect(hasDeactivated).toBe(true);
       expect(hasRunPostDeactivate).toBe(true);
     });
   });

--- a/test/focus-trap-react.test.js
+++ b/test/focus-trap-react.test.js
@@ -330,7 +330,7 @@ describe('FocusTrap', () => {
       render(
         <FocusTrapExample
           focusTrapOptions={{
-            checkCanFocusTrap: () => pause(500),
+            checkCanFocusTrap: () => pause(5),
             onActivate: () => {
               hasActivated = true;
             },
@@ -352,12 +352,12 @@ describe('FocusTrap', () => {
       expect(hasActivated).toBe(true);
       expect(hasRunPostActivate).toBe(false);
 
-      await pause(5);
+      await pause(3);
 
       expect(hasActivated).toBe(true);
       expect(hasRunPostActivate).toBe(false);
 
-      await pause(550);
+      await pause(6);
 
       expect(hasActivated).toBe(true);
       expect(hasRunPostActivate).toBe(true);
@@ -369,7 +369,7 @@ describe('FocusTrap', () => {
       render(
         <FocusTrapExample
           focusTrapOptions={{
-            checkCanReturnFocus: () => pause(500),
+            checkCanReturnFocus: () => pause(5),
             onDeactivate: () => {
               hasDeactivated = true;
             },
@@ -399,12 +399,12 @@ describe('FocusTrap', () => {
       expect(hasDeactivated).toBe(true);
       expect(hasRunPostDeactivate).toBe(false);
 
-      await pause(5);
+      await pause(3);
 
       expect(hasDeactivated).toBe(true);
       expect(hasRunPostDeactivate).toBe(false);
 
-      await pause(550);
+      await pause(6);
 
       expect(hasDeactivated).toBe(true);
       expect(hasRunPostDeactivate).toBe(true);


### PR DESCRIPTION
<!--
Thank you for your contribution! 🎉

Please be sure to go over the PR CHECKLIST below before posting your PR to make sure we all think of "everything". :)
-->

- Adding 2 new animated demos
- Adding the new values to PropTypes
- Adding support for `checkCanReturnFocus` and `onPostDeactivate`
- Adding Cypress tests for the new demos

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain:
  - Stated browser compatibility.
  - Stated React compatibility.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Prop-types added/updated.
- Typings added/updated.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
