### PR TITLE
[#415] Update to focus-trap 6.6.0

### DIFF
--- a/.changeset/selfish-dancers-wonder.md
+++ b/.changeset/selfish-dancers-wonder.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': minor
+---
+
+Update to support new features in `focus-trap@6.6.0` including `initialFocus` which can now be false to prevent initial focus, and `escapeDeactivates` which can now alternately be a function that returns a boolean instead of a straight boolean.

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "typescript": "^4.3.4"
   },
   "dependencies": {
-    "focus-trap": "^6.5.1"
+    "focus-trap": "^6.6.0"
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -251,13 +251,14 @@ FocusTrap.propTypes = {
       PropTypes.instanceOf(ElementType),
       PropTypes.string,
       PropTypes.func,
+      PropTypes.bool,
     ]),
     fallbackFocus: PropTypes.oneOfType([
       PropTypes.instanceOf(ElementType),
       PropTypes.string,
       PropTypes.func,
     ]),
-    escapeDeactivates: PropTypes.bool,
+    escapeDeactivates: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
     clickOutsideDeactivates: PropTypes.oneOfType([
       PropTypes.bool,
       PropTypes.func,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4272,10 +4272,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.0.tgz#a5d06b4a8b01e3a63771daa5cb7a1903e2e57067"
   integrity sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==
 
-focus-trap@^6.5.1:
-  version "6.5.1"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.5.1.tgz#2d2bb91198f17e8bc52070f1fb48ac36be4230b5"
-  integrity sha512-q57JebeQXVThn9DWvWLP2rUwuArvk8w3PyqZLSddto0thmVmklFzYJQO97Aq3pUcWkTXjflUa88fT0CrASsaHQ==
+focus-trap@^6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.6.0.tgz#7fb37679926ec1bd762d0748b056c68a64a9e8cf"
+  integrity sha512-2hWVR3XbBejn5v8wDW9DFzLWXcxMNaSJ/CtE3E+FJjjBCLwIYbZJwjUi2RDBfQPM58gHEt5hck0jrJgHR9/s+A==
   dependencies:
     tabbable "^5.2.0"
 


### PR DESCRIPTION
Fixes #415

- `initialFocus` can now be false
- `escapeDeactivates` can now be a function that returns a boolean

Typings don't need updating because they are imported from focus-trap.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain:
  - Stated browser compatibility.
  - Stated React compatibility.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Prop-types added/updated.
- Typings added/updated.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
