### PR TITLE
Bump focus-trap dependency to v6.7.0

### DIFF
--- a/.changeset/blue-peas-matter.md
+++ b/.changeset/blue-peas-matter.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': minor
+---
+
+Bump focus-trap dependency to v6.7.0

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "typescript": "^4.4.3"
   },
   "dependencies": {
-    "focus-trap": "^6.6.1"
+    "focus-trap": "^6.7.0"
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4383,10 +4383,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.0.tgz#a5d06b4a8b01e3a63771daa5cb7a1903e2e57067"
   integrity sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==
 
-focus-trap@^6.6.1:
-  version "6.6.1"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.6.1.tgz#761ce2c82ddd72beeb049e968bc8414e25b704aa"
-  integrity sha512-x9BWuAeF5UrfWuYKJ3jYrjcVYSYptS9CqtxH5IH7lPlZrMsaugKeAa0HtoZSBZe5DmeTMx2m0qY464ZMzqarzw==
+focus-trap@^6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.7.0.tgz#9b8660ca7d4c621dae7529e73f30e4e59e4419b4"
+  integrity sha512-Srd0gR1sq0gfvXNDWkrrW0DbOBoKA5k0iHLTX03Pg/Y9u9xy2tlu3rSgozecCcH10Qj7CV+6nglv0G3YpQ98VA==
   dependencies:
     tabbable "^5.2.1"
 


### PR DESCRIPTION
Fixes #452 (`initialFocus` option typings)

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain:
  - Stated browser compatibility.
  - Stated React compatibility.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Prop-types added/updated.
- Typings added/updated.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
