### PR TITLE
[#539] Fix incorrect reference to document

### DIFF
--- a/.changeset/witty-moose-draw.md
+++ b/.changeset/witty-moose-draw.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': patch
+---
+
+Fix bug where global document was being accessed instead of first checking for `focusTrapOptions.document` option (#539)

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -53,6 +53,20 @@ class FocusTrap extends React.Component {
     this.updatePreviousElement();
   }
 
+  /**
+   * Gets the configured document.
+   * @returns {Document|undefined} Configured document, falling back to the main
+   *  document, if it exists. During SSR, `undefined` is returned since the
+   *  document doesn't exist.
+   */
+  getDocument() {
+    // SSR: careful to check if `document` exists before accessing it as a variable
+    return (
+      this.props.focusTrapOptions.document ||
+      (typeof document !== 'undefined' ? document : undefined)
+    );
+  }
+
   // TODO: Need more test coverage for this function
   getNodeForOption(optionName) {
     const optionValue = this.tailoredFocusTrapOptions[optionName];
@@ -63,7 +77,7 @@ class FocusTrap extends React.Component {
     let node = optionValue;
 
     if (typeof optionValue === 'string') {
-      node = document.querySelector(optionValue);
+      node = this.getDocument()?.querySelector(optionValue);
       if (!node) {
         throw new Error(`\`${optionName}\` refers to no known node`);
       }
@@ -87,10 +101,7 @@ class FocusTrap extends React.Component {
 
   /** Update the previously focused element with the currently focused element. */
   updatePreviousElement() {
-    // SSR: careful to check if `document` exists before accessing it as a variable
-    const currentDocument =
-      this.props.focusTrapOptions.document ||
-      (typeof document !== 'undefined' ? document : undefined);
+    const currentDocument = this.getDocument();
     if (currentDocument) {
       this.previouslyFocusedElement = currentDocument.activeElement;
     }


### PR DESCRIPTION
Code was accessing `document` global instead of first checking
for the `focusTrapOptions.document` setting.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain:
  - Stated browser compatibility.
  - Stated React compatibility.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Prop-types added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
