### PR TITLE
Add shadow DOM support with ft v6.8.1

### DIFF
--- a/.changeset/olive-bears-relate.md
+++ b/.changeset/olive-bears-relate.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': minor
+---
+
+Bumps focus-trap to v6.8.0. The big new feature is opt-in Shadow DOM support in focus-trap (in tabbable), and a new `getShadowRoot` tabbable option exposed in a new `focusTrapOptions.tabbableOptions` configuration option.

--- a/.changeset/olive-bears-relate.md
+++ b/.changeset/olive-bears-relate.md
@@ -2,4 +2,8 @@
 'focus-trap-react': minor
 ---
 
+<<<<<<< HEAD
 Bumps focus-trap to v6.8.0. The big new feature is opt-in Shadow DOM support in focus-trap (in tabbable), and a new `getShadowRoot` tabbable option exposed in a new `focusTrapOptions.tabbableOptions` configuration option.
+=======
+Bumps focus-trap to v6.8.1. The big new feature is opt-in Shadow DOM support in focus-trap (in tabbable), and new tabbable options exposed in a new `focusTrapOptions.tabbableOptions` configuration option.
+>>>>>>> 57d9caa (Add shadow DOM support with ft v6.8.1)

--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ ReactDOM.render(<Demo />, document.getElementById('root'));
 
 Type: `Object`, optional
 
-Pass any of the options available in [`focus-trap`'s `createOptions`](https://github.com/focus-trap/focus-trap#focustrap--createfocustrapelement-createoptions).
+Pass any of the options available in focus-trap's [createOptions](https://github.com/focus-trap/focus-trap#createoptions).
+
+> ⚠️ See notes about __[testing in JSDom](#testing-in-jsdom)__ (e.g. using Jest) if that's what you currently use.
 
 #### active
 
@@ -168,6 +170,20 @@ If passed in, these elements will be used as the boundaries for the focus-trap, 
 If `containerElements` is subsequently updated (i.e. after the trap has been created) to an empty array (or an array of falsy values like `[null, null]`), the trap will still be active, but the TAB key will do nothing because the trap will not contain any tabbable groups of nodes. At this point, the trap can either be deactivated manually or by unmounting, or an updated set of elements can be given to `containerElements` to resume use of the TAB key.
 
 Using `containerElements` does require the use of React refs which, by nature, will require at least one state update in order to get the resolved elements into the prop, resulting in at least one additional render. In the normal case, this is likely more than acceptable, but if you really want to optimize things, then you could consider [using focus-trap directly](https://codesandbox.io/s/focus-trapreact-containerelements-demos-v5ydi) (see `Trap2.js`).
+
+## Help
+
+### Testing in JSDom
+
+> ⚠️ JSDom is not officially supported. Your mileage may vary, and tests may break from one release to the next (even a patch or minor release).
+>
+> This topic is just here to help with what we know may affect your tests.
+
+In general, a focus trap is best tested in a full browser environment such as Cypress, Playwright, or Nightwatch where a full DOM is available.
+
+Sometimes, that's not entirely desirable, and depending on what you're testing, you may be able to get away with using JSDom (e.g. via Jest), but you'll have to configure your traps using the `focusTrapOptions.tabbableOptions.displayCheck: 'none'` option.
+
+See [Testing focus-trap in JSDom](https://github.com/focus-trap/focus-trap#testing-in-jsdom) for more details.
 
 ## Contributing
 

--- a/cypress/integration/focus-trap-demo.spec.js
+++ b/cypress/integration/focus-trap-demo.spec.js
@@ -375,4 +375,16 @@ describe('<FocusTrap> component', () => {
       });
     });
   });
+
+  // describe('demo: with-shadow-dom', () => {
+  //   TL/DR: Unfortunately, the https://github.com/Bkucera/cypress-plugin-tab plugin doesn't
+  //    support Shadow DOM, and Cypress itself doesn't have great support for it either
+  //    (see more info below) so there's no point in writing a test for this demo at this time.
+  //   NOTE: Because of how Cypress interacts with Shadown DOMs, it sees the shadow as a black
+  //    box that has focus, so that limits what we can check for in expectations (e.g. we can't
+  //    effectively check that an element inside a shadow has focus; Cypress will always say yes
+  //    because something inside has focus, but it doesn't know what, exactly...). Also, the
+  //    cypress-plugin-tab will complain if we try to .tab() from inside the shadow host saying
+  //    it's not a tabbable element because it doesn't appear to support shadow DOM.
+  // });
 });

--- a/demo/index.html
+++ b/demo/index.html
@@ -131,6 +131,7 @@
         View demo source <span aria-hidden="true">&gt;&gt;</span>
       </a>
     </p>
+
     <h2 id="iframe-heading">demo Iframe with document option applied</h2>
     <p>
       When integrated in an iframe, you may specify the document (of the said
@@ -149,7 +150,20 @@
         View demo source <span aria-hidden="true">&gt;&gt;</span>
       </a>
     </p>
-    <div id="demo-iframe" />
+    <div id="demo-iframe"></div>
+
+    <h2 id="with-shadow-dom-heading">with shadow dom</h2>
+    <p>
+      This focus trap <em>contains</em> tabbable elements that are <strong>inside</strong>
+      open and closed Shadow DOMs. It configures <code>tabbable</code> to look for Shadow DOM
+      elements and provides a reference to the closed Shadow when requested.
+    </p>
+    <div id="demo-with-shadow-dom"></div>
+    <p>
+      <a href="https://github.com/focus-trap/focus-trap-react/blob/master/demo/js/demo-defaults.js" aria-describedby="defaults-heading">
+        View demo source <span aria-hidden="true">&gt;&gt;</span>
+      </a>
+    </p>
 
     <p>
       <span aria-hidden="true" style="font-size:2em;vertical-align:middle;">☜</span>

--- a/demo/js/demo-with-shadow-dom.js
+++ b/demo/js/demo-with-shadow-dom.js
@@ -1,0 +1,107 @@
+const React = require('react');
+const ReactDOM = require('react-dom');
+const FocusTrap = require('../../dist/focus-trap-react');
+
+const createShadow = function (hostEl, isOpen) {
+  const containerEl = document.createElement('div');
+  containerEl.id = 'with-shadow-dom-closed-container';
+  containerEl.style = `border: 1px dotted black; margin-top: 10px; padding: 10px; background-color: ${
+    isOpen ? 'transparent' : 'rgba(0, 0, 0, 0.05)'
+  };`;
+  containerEl.innerHTML = `
+    <p style="margin-top: 0; padding-top: 0;">
+      This field is inside a <strong>${
+        isOpen ? 'opened' : 'closed'
+      }</strong> Shadow DOM:
+    </p>
+    <input id="text-input" type="text" />
+  `;
+
+  // use same styles as host
+  const styleLinkEl = document.createElement('link');
+  styleLinkEl.setAttribute('rel', 'stylesheet');
+  styleLinkEl.setAttribute('href', 'style.css');
+
+  const shadowEl = hostEl.attachShadow({ mode: isOpen ? 'open' : 'closed' });
+  shadowEl.appendChild(styleLinkEl);
+  shadowEl.appendChild(containerEl);
+
+  return shadowEl;
+};
+
+const DemoWithShadowDom = function () {
+  const [active, setActive] = React.useState(false);
+  const openedShadowHostRef = React.useRef(null);
+  const openedShadowRef = React.useRef(null);
+  const closedShadowHostRef = React.useRef(null);
+  const closedShadowRef = React.useRef(null);
+
+  const handleTrapActivate = React.useCallback(function () {
+    setActive(true);
+  }, []);
+
+  const handleTrapDeactivate = React.useCallback(function () {
+    setActive(false);
+  }, []);
+
+  React.useEffect(function () {
+    if (openedShadowHostRef.current && !openedShadowRef.current) {
+      openedShadowRef.current = createShadow(openedShadowHostRef.current, true);
+    }
+
+    if (closedShadowHostRef.current && !closedShadowRef.current) {
+      closedShadowRef.current = createShadow(
+        closedShadowHostRef.current,
+        false
+      );
+    }
+  }, []);
+
+  return (
+    <div>
+      <p>
+        <button
+          onClick={handleTrapActivate}
+          aria-describedby="with-shadow-dom-heading"
+        >
+          activate trap
+        </button>
+      </p>
+      <FocusTrap
+        active={active}
+        focusTrapOptions={{
+          onDeactivate: handleTrapDeactivate,
+          tabbableOptions: {
+            getShadowRoot(node) {
+              if (node === closedShadowHostRef.current) {
+                return closedShadowHostRef.current;
+              }
+            },
+          },
+        }}
+      >
+        <div className={`trap ${active ? 'is-active' : ''}`}>
+          <p>
+            Here is a focus trap <a href="#">with</a> <a href="#">some</a>{' '}
+            <a href="#">focusable</a> parts.
+          </p>
+          <div id="with-shadow-dom-opened-host" ref={openedShadowHostRef}></div>
+          <div id="with-shadow-dom-closed-host" ref={closedShadowHostRef}></div>
+          <p>
+            <button
+              onClick={handleTrapDeactivate}
+              aria-describedby="with-shadow-dom-heading"
+            >
+              deactivate trap
+            </button>
+          </p>
+        </div>
+      </FocusTrap>
+    </div>
+  );
+};
+
+ReactDOM.render(
+  <DemoWithShadowDom />,
+  document.getElementById('demo-with-shadow-dom')
+);

--- a/demo/js/index.js
+++ b/demo/js/index.js
@@ -8,3 +8,4 @@ require('./demo-containerelements');
 require('./demo-containerelements-childless');
 require('./demo-setReturnFocus');
 require('./demo-iframe');
+require('./demo-with-shadow-dom'); // TEST MANUALLY (Cypress doesn't support Shadow DOM well)

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "focus-trap": "^6.7.3"
+    "focus-trap": "^6.8.0"
   },
   "peerDependencies": {
     "prop-types": "^15.8.1",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "typescript": "^4.6.3"
   },
   "dependencies": {
-    "focus-trap": "^6.8.0"
+    "focus-trap": "^6.8.1"
   },
   "peerDependencies": {
     "prop-types": "^15.8.1",

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -312,6 +312,7 @@ FocusTrap.propTypes = {
     allowOutsideClick: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
     preventScroll: PropTypes.bool,
     tabbableOptions: PropTypes.shape({
+      displayCheck: PropTypes.oneOf(['full', 'non-zero-area', 'none']),
       getShadowRoot: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
     }),
   }),

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -311,6 +311,9 @@ FocusTrap.propTypes = {
     ]),
     allowOutsideClick: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
     preventScroll: PropTypes.bool,
+    tabbableOptions: PropTypes.shape({
+      getShadowRoot: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
+    }),
   }),
   containerElements: PropTypes.arrayOf(PropTypes.instanceOf(ElementType)),
   children: PropTypes.oneOfType([

--- a/yarn.lock
+++ b/yarn.lock
@@ -4329,12 +4329,12 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.0.tgz#a5d06b4a8b01e3a63771daa5cb7a1903e2e57067"
   integrity sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==
 
-focus-trap@^6.7.3:
-  version "6.7.3"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.7.3.tgz#b5dc195b49c90001f08a63134471d1e6dd381ddd"
-  integrity sha512-8xCEKndV4KrseGhFKKKmczVA14yx1/hnmFICPOjcFjToxCJYj/NHH43tPc3YE/PLnLRNZoFug0EcWkGQde/miQ==
+focus-trap@^6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.8.0.tgz#6b853176593cc68a511e54a6ca466bcbe9e5601b"
+  integrity sha512-VXObAEbVGSAV1FqeveDY1X4jegkl8qjewUCDU2VYk+smVgZHW9wcpfyEpD4UuTkmzg3y+r4Xx2x0gCSJVowMaw==
   dependencies:
-    tabbable "^5.2.1"
+    tabbable "5.3.0"
 
 follow-redirects@^1.14.0:
   version "1.14.8"
@@ -8300,10 +8300,10 @@ syntax-error@^1.1.1:
   dependencies:
     acorn-node "^1.2.0"
 
-tabbable@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.1.tgz#e3fda7367ddbb172dcda9f871c0fdb36d1c4cd9c"
-  integrity sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ==
+tabbable@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.0.tgz#1c745a67e8cbdc0a3e0c19e912f28ef90514a510"
+  integrity sha512-BS+sw22/pUGaIZr8Ro8E+NeJ3bhvYgMHJKEAhr9pGj22MqaD60qyrvGJBSe6AlrOHR8Y41nA0IvMmgf4lVWC9Q==
 
 term-color@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4329,12 +4329,12 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.0.tgz#a5d06b4a8b01e3a63771daa5cb7a1903e2e57067"
   integrity sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==
 
-focus-trap@^6.8.0:
-  version "6.8.0"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.8.0.tgz#6b853176593cc68a511e54a6ca466bcbe9e5601b"
-  integrity sha512-VXObAEbVGSAV1FqeveDY1X4jegkl8qjewUCDU2VYk+smVgZHW9wcpfyEpD4UuTkmzg3y+r4Xx2x0gCSJVowMaw==
+focus-trap@^6.8.1:
+  version "6.8.1"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.8.1.tgz#0c9e4e44db8f7242f3d4b1056a518747d9c97125"
+  integrity sha512-sdz/jAPiP/9cyElo31+X3/estGPi6wgHutg+R/3MFmJtMM5AeeBlFGplejQyy89Ouyds/9xW+qPEH3jFlOAuKg==
   dependencies:
-    tabbable "5.3.0"
+    tabbable "^5.3.1"
 
 follow-redirects@^1.14.0:
   version "1.14.8"
@@ -8300,10 +8300,10 @@ syntax-error@^1.1.1:
   dependencies:
     acorn-node "^1.2.0"
 
-tabbable@5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.0.tgz#1c745a67e8cbdc0a3e0c19e912f28ef90514a510"
-  integrity sha512-BS+sw22/pUGaIZr8Ro8E+NeJ3bhvYgMHJKEAhr9pGj22MqaD60qyrvGJBSe6AlrOHR8Y41nA0IvMmgf4lVWC9Q==
+tabbable@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.1.tgz#059f2a19b829efce2a0ec05785a47dd3bcd0a25b"
+  integrity sha512-NtO7I7eoAHR+JwwcNsi/PipamtAEebYDnur/k9wM6n238HHy/+1O4+7Zx7e/JaDAbKJPlIFYsfsV/6tPqTOQvg==
 
 term-color@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Adds a demo that uses open and closed shadows.

Does NOT add a test for this demo because of lack of support for
Shadow DOM in Cypress (see comment in focus-trap-demo.spec.js).

Adds a warning to the README about testing in JSDom, and fixes
all the JSDom-based tests to use `displayCheck='none'` to get
around JSDom limitations with new APIs used by tabbable in
v5.3.0.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain:
  - Stated browser compatibility.
  - Stated React compatibility.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Prop-types added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
