### PR TITLE
Add explicit dependency on tabbable.

### DIFF
--- a/.changeset/strange-mirrors-serve.md
+++ b/.changeset/strange-mirrors-serve.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': patch
+---
+
+Add explicit dependency on tabbable.

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "focus-trap": "^6.9.2"
+    "focus-trap": "^6.9.2",
+    "tabbable": "^5.3.2"
   },
   "peerDependencies": {
     "prop-types": "^15.8.1",


### PR DESCRIPTION
This project directly imports tabbable, but relies on it being available
transitively through its dependency on focus-trap. This makes this
package incompatible with yarn v2/v3, which requires that packages
explicitly state all dependencies.

It's also, more generally, best practice to explicitly declare all
dependencies. This helps ensure that package managers provide the
appropriate versions of dependencies to their requesting packages.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain:
  - Stated browser compatibility.
  - Stated React compatibility.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Prop-types added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
