### PR TITLE
[#705] Fix setReturnFocus option as function not getting prev node

### DIFF
--- a/.changeset/funny-turkeys-sleep.md
+++ b/.changeset/funny-turkeys-sleep.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': patch
+---
+
+Fix setReturnFocus option as function not being passed node focused prior to activation.

--- a/demo/js/demo-setReturnFocus.js
+++ b/demo/js/demo-setReturnFocus.js
@@ -10,7 +10,14 @@ const DemoSetReturnFocusDialog = () => {
 
   const focusTrapOptions = useMemo(
     () => ({
-      setReturnFocus: '#AlternateReturnFocusElement',
+      setReturnFocus: (prevSelNode) => {
+        // contrived code to prove during tests that the setReturnFocus() option
+        //  can be a function that is given a reference to the node that was focused
+        //  prior to trap activation
+        return prevSelNode.parentNode.querySelector(
+          '#AlternateReturnFocusElement'
+        );
+      },
       onDeactivate: () => setIsTrapActive(false),
     }),
     []


### PR DESCRIPTION
Fixes #705

When the `setReturnFocus` option is a function, it should get the
previously focused node prior to activation as its first parameter,
yet it was not because of the special handling in focus-trap-react
for trap deactivation.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain:
  - Stated browser compatibility.
  - Stated React compatibility.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Prop-types added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
