### PR TITLE
Bump focus-trap to 7.2.0

### DIFF
--- a/.changeset/rich-dingos-type.md
+++ b/.changeset/rich-dingos-type.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': patch
+---
+
+Add missing trapStack option from focus-trap 7.1.0, add new isKeyForward and isKeyBackward options from focus-trap 7.2.0, bump focus-trap to 7.2.0.

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "typescript": "^4.9.3"
   },
   "dependencies": {
-    "focus-trap": "^7.1.0",
+    "focus-trap": "^7.2.0",
     "tabbable": "^6.0.1"
   },
   "peerDependencies": {

--- a/src/focus-trap-react.js
+++ b/src/focus-trap-react.js
@@ -461,6 +461,9 @@ FocusTrap.propTypes = {
       ]),
       getShadowRoot: PropTypes.oneOfType([PropTypes.bool, PropTypes.func]),
     }),
+    trapStack: PropTypes.array,
+    isKeyForward: PropTypes.func,
+    isKeyBackward: PropTypes.func,
   }),
   containerElements: PropTypes.arrayOf(PropTypes.instanceOf(ElementType)), // DOM element ONLY
   children: PropTypes.oneOfType([

--- a/yarn.lock
+++ b/yarn.lock
@@ -4268,10 +4268,10 @@ flatted@^3.1.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.1.0.tgz#a5d06b4a8b01e3a63771daa5cb7a1903e2e57067"
   integrity sha512-tW+UkmtNg/jv9CSofAKvgVcO7c2URjhTdW1ZTkcAritblu8tajiYy7YisnIflEwtKssCtOxpnBRoCB7iap0/TA==
 
-focus-trap@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-7.1.0.tgz#3226e977d76b1fd555c2e4f7ff91f10371f0f2cc"
-  integrity sha512-CuJvwUBfJCWcU6fc4xr3UwMF5vWnox4isXAixCwrPzCsPKOQjP9T+nTlYT2t+vOmQL8MOQ16eim99XhjQHAuiQ==
+focus-trap@^7.2.0:
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-7.2.0.tgz#25af61b5635d3c18cd2fd176087db7b60be72c6b"
+  integrity sha512-v4wY6HDDYvzkBy4735kW5BUEuw6Yz9ABqMYLuTNbzAFPcBOGiGHwwcNVMvUz4G0kgSYh13wa/7TG3XwTeT4O/A==
   dependencies:
     tabbable "^6.0.1"
 


### PR DESCRIPTION
Add missing trapStack option from 7.1.0 and new isKeyForward/isKeyBackward options from 7.2.0.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain:
  - Stated browser compatibility.
  - Stated React compatibility.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Prop-types added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `yarn changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
