### PR TITLE
[#986] Bump focus-trap to v7.4.1 for nwsapi patch in tabbable v6.1.2

### DIFF
--- a/.changeset/loud-peaches-share.md
+++ b/.changeset/loud-peaches-share.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': patch
+---
+
+Bump focus-trap to v7.4.1 and tabbable to v6.1.2 for nwsapi patch ([#986](https://github.com/focus-trap/focus-trap-react/issues/986)).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "10.1.1",
       "license": "MIT",
       "dependencies": {
-        "focus-trap": "^7.4.0",
+        "focus-trap": "^7.4.1",
         "tabbable": "^6.1.2"
       },
       "devDependencies": {
@@ -7914,11 +7914,11 @@
       "dev": true
     },
     "node_modules/focus-trap": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.0.tgz",
-      "integrity": "sha512-yI7FwUqU4TVb+7t6PaQ3spT/42r/KLEi8mtdGoQo2li/kFzmu9URmalTvw7xCCJtSOyhBxscvEAmvjeN9iHARg==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.1.tgz",
+      "integrity": "sha512-rnXP5ERIjlo1gEZp7hQb4ekYqUxRuSDQeyWvxhahH3/GkWtd8h8g1C8Eu/KGpuvbUWNVeogK0kuzzrM4u2Z9jA==",
       "dependencies": {
-        "tabbable": "^6.1.1"
+        "tabbable": "^6.1.2"
       }
     },
     "node_modules/follow-redirects": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "focus-trap": "^7.4.0",
+    "focus-trap": "^7.4.1",
     "tabbable": "^6.1.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
Fixes #986

Note that tabbable was already bumped separately earlier today by Dependabot in #989.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain:
  - Stated browser compatibility.
  - Stated React compatibility.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Prop-types added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `npm run changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
