### PR TITLE
Bump focus-trap to v7.4.3

### DIFF
--- a/.changeset/tall-ways-tie.md
+++ b/.changeset/tall-ways-tie.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': patch
+---
+
+Bump focus-trap to v7.4.3 for bug fix for ([#962](https://github.com/focus-trap/focus-trap-react/issues/962))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "focus-trap-react",
-  "version": "10.1.2",
+  "version": "10.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "focus-trap-react",
-      "version": "10.1.2",
+      "version": "10.1.3",
       "license": "MIT",
       "dependencies": {
-        "focus-trap": "^7.4.2",
+        "focus-trap": "^7.4.3",
         "tabbable": "^6.1.2"
       },
       "devDependencies": {
@@ -7914,9 +7914,9 @@
       "dev": true
     },
     "node_modules/focus-trap": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.2.tgz",
-      "integrity": "sha512-KMjf+H5uDWPkwSQVqE5r/+vOkP5zBWwVBoWPIZxU3gfg+M8IT+Y8s+vXQqZvHEIXyHPKHrSm6m4G4ceF98OZ8w==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.4.3.tgz",
+      "integrity": "sha512-BgSSbK4GPnS2VbtZ50VtOv1Sti6DIkj3+LkVjiWMNjLeAp1SH1UlLx3ULu/DCu4vq5R4/uvTm+zrvsMsuYmGLg==",
       "dependencies": {
         "tabbable": "^6.1.2"
       }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "typescript": "^5.0.4"
   },
   "dependencies": {
-    "focus-trap": "^7.4.2",
+    "focus-trap": "^7.4.3",
     "tabbable": "^6.1.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
Fixes #962 

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain:
  - Stated browser compatibility.
  - Stated React compatibility.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Prop-types added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `npm run changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
