### PR TITLE
Bump focus-trap to v7.5.2

### DIFF
--- a/.changeset/twenty-bees-scream.md
+++ b/.changeset/twenty-bees-scream.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': patch
+---
+
+Bump focus-trap to v7.5.2 for Safari-related bug fix with `Array.findLast()`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "focus-trap-react",
-  "version": "10.1.4",
+  "version": "10.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "focus-trap-react",
-      "version": "10.1.4",
+      "version": "10.2.0",
       "license": "MIT",
       "dependencies": {
-        "focus-trap": "^7.5.1",
+        "focus-trap": "^7.5.2",
         "tabbable": "^6.2.0"
       },
       "devDependencies": {
@@ -8100,9 +8100,9 @@
       "dev": true
     },
     "node_modules/focus-trap": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.1.tgz",
-      "integrity": "sha512-Xm2j/zkKGc9ORKrVrbOqwCiJc5XnQOiBtmpa1YmEW0jqmkJ4ZJnRShuMYnEuho6LO8KKsbrqjir89KQLIDKKqA==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
+      "integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
       "dependencies": {
         "tabbable": "^6.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "typescript": "^5.1.5"
   },
   "dependencies": {
-    "focus-trap": "^7.5.1",
+    "focus-trap": "^7.5.2",
     "tabbable": "^6.2.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Fixes a bug in Safari with `Array.findLast()` not being defined.

<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain:
  - Stated browser compatibility.
  - Stated React compatibility.
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Prop-types added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `npm run changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
