### PR TITLE
Bump focus-trap to 7.5.4 for shadow DOM fix

### DIFF
--- a/.changeset/grumpy-shirts-count.md
+++ b/.changeset/grumpy-shirts-count.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': patch
+---
+
+Bump focus-trap to v7.5.4 for shadow DOM related bug fix

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "10.2.2",
       "license": "MIT",
       "dependencies": {
-        "focus-trap": "^7.5.3",
+        "focus-trap": "^7.5.4",
         "tabbable": "^6.2.0"
       },
       "devDependencies": {
@@ -8245,9 +8245,9 @@
       "dev": true
     },
     "node_modules/focus-trap": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.3.tgz",
-      "integrity": "sha512-7UsT/eSJcTPF0aZp73u7hBRTABz26knRRTJfoTGFCQD5mUImLIIOwWWCrtoQdmWa7dykBi6H+Cp5i3S/kvsMeA==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
+      "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
       "dependencies": {
         "tabbable": "^6.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "typescript": "^5.2.2"
   },
   "dependencies": {
-    "focus-trap": "^7.5.3",
+    "focus-trap": "^7.5.4",
     "tabbable": "^6.2.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain:
  - Stated browser compatibility.
  - Stated React compatibility.
- Web APIs introduced have __deep__ browser coverage, including Safari (often very late to adopt new APIs).
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Prop-types added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `npm run changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
