### PR TITLE
Revert incorrect types introduced in v11

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,8 @@
 import { Options as FocusTrapOptions } from 'focus-trap';
 import * as React from 'react';
 
+export = FocusTrap;
+
 declare namespace FocusTrap {
   export interface Props extends React.AllHTMLAttributes<any> {
     children?: React.ReactNode;
@@ -11,4 +13,4 @@ declare namespace FocusTrap {
   }
 }
 
-export declare class FocusTrap extends React.Component<FocusTrap.Props> { }
+declare class FocusTrap extends React.Component<FocusTrap.Props> { }


### PR DESCRIPTION
`export declare class` means that there are named exports, but there are no named exports in src/focus-trap-react.js.

Therefore, `export = FocusTrap;` was the correct type definition.

Fixes #1396