### PR TITLE
Bump focus-trap to v7.6.4

### DIFF
--- a/.changeset/tiny-ghosts-swim.md
+++ b/.changeset/tiny-ghosts-swim.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': patch
+---
+
+Bump focus-trap dependency to v7.6.4 to get fix to manually-paused traps (see [focus-trap|1340](https://github.com/focus-trap/focus-trap/pull/1340) for more info)

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "11.0.2",
       "license": "MIT",
       "dependencies": {
-        "focus-trap": "^7.6.2",
+        "focus-trap": "^7.6.4",
         "tabbable": "^6.2.0"
       },
       "devDependencies": {
@@ -8487,9 +8487,10 @@
       "license": "ISC"
     },
     "node_modules/focus-trap": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.2.tgz",
-      "integrity": "sha512-9FhUxK1hVju2+AiQIDJ5Dd//9R2n2RAfJ0qfhF4IHGHgcoEUTMpbTeG/zbEuwaiYXfuAH6XE0/aCyxDdRM+W5w==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.4.tgz",
+      "integrity": "sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==",
+      "license": "MIT",
       "dependencies": {
         "tabbable": "^6.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "typescript": "^5.7.2"
   },
   "dependencies": {
-    "focus-trap": "^7.6.2",
+    "focus-trap": "^7.6.4",
     "tabbable": "^6.2.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain:
  - Stated browser compatibility.
  - Stated React compatibility.
- Web APIs introduced have __deep__ browser coverage, including Safari (often very late to adopt new APIs).
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Prop-types added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `npm run changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>
