### PR TITLE
Bump focus-trap to 8.1.0

### DIFF
--- a/.changeset/every-dryers-drop.md
+++ b/.changeset/every-dryers-drop.md
@@ -1,0 +1,5 @@
+---
+'focus-trap-react': patch
+---
+
+Update `focus-trap` dependency to 8.1.0 for new lifecycle hook improvements (`onActivate`, etc).

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "12.0.0",
       "license": "MIT",
       "dependencies": {
-        "focus-trap": "^8.0.1",
+        "focus-trap": "^8.1.0",
         "tabbable": "^6.4.0"
       },
       "devDependencies": {
@@ -8572,9 +8572,9 @@
       "license": "ISC"
     },
     "node_modules/focus-trap": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-8.0.1.tgz",
-      "integrity": "sha512-9ptSG6z51YQOstI/oN4XuVGP/03u2nh0g//qz7L6zX0i6PZiPnkcf3GenXq7N2hZnASXaMxTPpbKwdI+PFvxlw==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-8.1.0.tgz",
+      "integrity": "sha512-T65crff26CKV2CZ3csg5y05r+560srp0b8EbAif35euW58hzklVf/Gb4Q+/HCtB8e9III3QFEyk5BWV5XJuOyw==",
       "license": "MIT",
       "dependencies": {
         "tabbable": "^6.4.0"

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "typescript": "^6.0.3"
   },
   "dependencies": {
-    "focus-trap": "^8.0.1",
+    "focus-trap": "^8.1.0",
     "tabbable": "^6.4.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
<details>
<summary>PR Checklist</summary>
<br/>

__Please leave this checklist in your PR.__

- Issue being fixed is referenced.
- Source changes maintain:
  - Stated browser compatibility.
  - Stated React compatibility.
- Web APIs introduced have __deep__ browser coverage, including Safari (often very late to adopt new APIs).
- Unit test coverage added/updated.
- E2E test coverage added/updated.
- Prop-types added/updated.
- Typings added/updated.
- Changes do not break SSR:
  - Careful to test `typeof document/window !== 'undefined'` before using it in code that gets executed on load.
- README updated (API changes, instructions, etc.).
- Changes to dependencies explained.
- Changeset added (run `npm run changeset` locally to add one, and follow the prompts).
  - EXCEPTION: A Changeset is not required if the change does not affect any of the source files that produce the package bundle. For example, demo changes, tooling changes, test updates, or a new dev-only dependency to run tests more efficiently should not have a Changeset since it will not affect package consumers.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Dependencies**
  * Updated `focus-trap` to version 8.1.0 with enhanced lifecycle hook capabilities.

* **New Features**
  * New `onActivate` lifecycle hook available for improved control over focus-trap activation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->